### PR TITLE
docs: the design notes are nine features behind the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **917 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **918 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -341,7 +341,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 917 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 918 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -385,7 +385,7 @@ missed one costs a merge conflict in an unattended run with nobody watching.
 
 ## Validated primitives
 
-`test/run.py` — 917 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
+`test/run.py` — 918 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
 skip loudly, naming the dependency. `prototype/` holds the original shell POC (7 assertions run
 anywhere, 5 skip), kept for the record; `prototype/br_gate.sh` is superseded by
 `lib/showrunner/gates.py`, which parses the graph as JSON instead of splitting records on a literal

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,142 +1,423 @@
 # showrunner — design notes
 
 Working notes, not a spec. Records the decisions and the reasons, including the ones that only
-became obvious by running the thing.
+became obvious by running the thing against a real codebase and losing.
+
+Structure: the two axes, then the seam with the layer below, then the rule the whole design keeps
+rediscovering, then the areas where that rule cost something to learn — isolation, adoption,
+premises, observability, distribution — then what is still open.
+
+---
 
 ## Two axes (why showrunner ≠ game_loop)
 
-- **game_loop = vertical:** integrity within one session (autonomy engine + safety hooks + the
-  "name a real file" honesty gate). Enforced by Claude Code hooks. Power = narrowness.
-- **showrunner = horizontal:** breadth across work and agents (dependency graph, parallel lanes,
-  shared locks, resume). A different job → a different repo.
+- **game_loop = vertical:** integrity within one session — the autonomy engine, the safety hooks,
+  the "name a real file" honesty gate. Enforced by Claude Code hooks. Its power is its narrowness.
+- **showrunner = horizontal:** breadth across work and agents — a dependency graph, parallel
+  lanes in separate worktrees, cross-process locks over single-consumer resources, and resume. A
+  different job, so a different repo.
 
-Dependency direction: **showrunner → game_loop + br.** The primitives never learn showrunner exists.
+Dependency direction: **showrunner → game_loop + br**, and the primitives never learn showrunner
+exists. Both are optional; everything showrunner guarantees works without either.
 
-## Decision: the work-graph is vendored, with a br adapter
+**Crawler** is the only piece of vocabulary that matters: one Claude Code session, in its own
+worktree, with its own scratch dir and its own brief, working one leaf.
 
-`br ready` was originally described as the only work-discovery entrypoint, which made a Rust
-toolchain and a separate tracker load-bearing for every loop iteration. The layer below reaches as
-far as it does substantially because it has **no install step worth the name**, and showrunner
-inherits that audience; every dependency is a place adoption stops, and this one sat in front of the
-*first* command.
+---
 
-So: a minimal graph over Python's built-in `sqlite3`, and a `br` adapter that is preferred when br is
-genuinely present. Both sit behind one `Graph` interface, and nothing else in showrunner learns which
-backend it got (`lib/showrunner/graph.py`).
+## The seam
 
-Two capabilities the vendored backend has that a general tracker does not, because an orchestrator
-needs them:
+The interesting edge is enforcement over shared resources, and it splits cleanly:
 
-- **Claims carry liveness** (pid + boot token + worktree + session).
-- **`refuted` is a terminal state** distinct from `closed`.
+- The **lock** — shared cross-process state — is showrunner's.
+- The **guard** that consults it before a risky verb is a game_loop-shaped **PreToolUse hook**
+  running inside each Crawler. `showrunner lock guard` exits 2, the deny code.
+- So game_loop grows a generic "check this external lock before these verbs" seam and showrunner
+  supplies the lock path. game_loop never learns the word "device".
 
-The br adapter cannot answer `stale_claims()` — br records no liveness on a claim — so it **raises
-rather than returning an empty list**. Returning `[]` would read as "nothing is stale", which is the
-one answer that must never be produced by not knowing.
+Same shape for turn-ends: game_loop provides the hook mechanism, showrunner provides the graph and
+the policy those gates read (`showrunner stop-gate`, also exit 2).
 
-## The boundary (the seam)
+`lock run` is deliberately **not** a hook verb. Routing and guarding are optimisations; `lock run`
+is the guarantee. A missing install costs the optimisation and keeps the guarantee, which is the
+only reason the fail-open posture below is acceptable.
 
-The interesting edge is enforcement of shared resources:
-
-- The **lock** (shared cross-process state) is showrunner's.
-- The **guard** that checks it before a risky verb is a game_loop-shaped **PreToolUse hook** running
-  inside each Crawler — `showrunner lock guard` exits 2, which is the deny code.
-- So game_loop's write-guard grows a generic "check this external lock before these verbs" seam, and
-  **showrunner supplies the lock path.** game_loop stays generic — it never learns the word "device."
-
-Likewise: game_loop provides the *hook mechanism* for a Stop gate / a done gate; showrunner provides
-the *graph + policy* those gates read (`showrunner stop-gate`, also exit 2).
+---
 
 ## The rule the whole design keeps rediscovering
 
-**A degraded guard must fail loud, never quiet.** Every failure mode that actually hurt in a real run
-had the same shape: not an error, but *silence*.
+**A degraded guard must fail loud, never quiet.** Every failure mode that actually hurt had the
+same shape — not an error, but *silence*. A mutex that is silently a no-op is worse than no mutex,
+because nobody inside a single Crawler can observe the collision.
 
 | The mechanism | How it goes quiet | What now happens |
 |---|---|---|
 | the resource lock | a worktree-relative lock root gives N trees N locks | refused at config load |
-| the stop gate | `sed`/`grep` over JSON stops matching after a field-order change | parsed as JSON; unrecognised shape refuses |
+| the stop gate | `sed`/`grep` over JSON stops matching after a field-order change | parsed as JSON; an unrecognised shape refuses |
 | the br adapter | an unparseable response reads as an empty graph | refuses, naming the command and the output |
 | a claim | its owner dies and the leaf never returns to `ready` | pid + boot token; `reap` reclaims loudly |
 | the close gate | any non-empty file satisfies `[ -s "$proof" ]` | proof must postdate the claim, and is recorded |
-| a check comparison | a failure with no parseable lines looks like no failure | marked `exit-code-only` and reported as degraded |
-| the collision estimate | an unestimable leaf looks like a leaf that collides with nothing | treated as colliding with everything, with the reason printed |
+| a check comparison | a failure with no parseable lines looks like no failure | marked `exit-code-only`, reported as degraded |
+| the collision estimate | an unestimable leaf looks like one that collides with nothing | treated as colliding with everything, reason printed |
 | lane routing | an unmatched leaf silently takes the default | defaults conservatively **and says the rule is missing** |
+| a fail-open hook | an allow nobody is told about looks like a guard that ran and was content | prints `ALLOWED WITHOUT BEING CHECKED` |
+| the waiting probe | an empty queue and a wedged run both stop producing output | `waiting` distinguishes them, and its BLOCKED lines go to stderr with a distinct exit code |
+| **showrunner itself** | a party that never registered leaves every showrunner guard correctly idle | `whoami` on both session seams, and `dispatch guard` on the path the bypass actually uses |
+
+The last row is the uncomfortable one: it took a real run to see, and it was the only row where
+the answer had to be built rather than tightened.
+
+---
+
+## Adoption is a design surface, not a documentation problem
+
+**The failure.** In a 16-hour unattended run in a consumer repo that had *both* harnesses
+installed and wired, one orchestrator dispatched 42 worker sessions. Every one used game_loop.
+None used showrunner. The same orchestrator had run a showrunner campaign in that repo the week
+before — 38 leaves closed, the campaign still on disk — and still hand-rolled `git worktree add`
+isolation, hand-diffed file lists to sequence waves, and collected results from `.out` files.
+
+It was not a preference. Four causes, and only the first is showrunner's:
+
+1. **game_loop owns `SessionStart` and `PostCompact`; showrunner owns neither.** Every session
+   game_loop guards is *greeted* by it without choosing it, and re-greeted after every compaction.
+   Nothing in showrunner fires at a session boundary, so each compaction refreshed one tool and
+   eroded the other. Adoption decays at exactly the rate context does.
+2. **Both showrunner hooks read showrunner's own state.** `worktree-guard` denies when a lease is
+   held by a different live session; `inert-crawler-gate` refuses when `waiting` reports a live,
+   inert Crawler. A lane that never registered holds no lease and is no Crawler, so both hooks
+   correctly exit 0 — and 42 unregistered lanes, five of them dying at a background-task ceiling
+   and two landing on one branch, produced a journal that read as a healthy campaign throughout.
+3. **The consumer's own seat was declared in a writable file.** A local prototype gated two
+   org-chart guards on a one-word `seat` file. It said `worker`, written mid-run, so both exited 0
+   for sixteen hours and nothing announced it.
+4. **The consumer's dispatch guard matched the wrong tool.** Its PreToolUse matcher was `Agent`
+   while every real dispatch went out as Bash `nohup claude -p`. The guard built to stop flat
+   dispatch was blind to the mechanism used, 42 consecutive times.
+
+**What this means for the design.** Enforcement-in-artifacts has to apply to a tool's *own entry
+point*, not only to the work it guards. The test showrunner already applies to everything else —
+*if the agent ignored every instruction, would this still hold?* — was never applied to "is
+showrunner reached for at all", and the answer is no. A guard whose enabling condition is "you
+already adopted me" is not a guard.
+
+**What shipped (#36, #37, #40).** `whoami`, registered on `SessionStart` **and** `PostCompact`, prints three things: the seat this session holds, the stack that seat uses, and
+what that seat may not do. With two properties that the prototype got wrong first:
+
+- **The seat is derived, never declared.** A linked worktree is a `crawler`, and `campaign.json`
+  names its leaf. The main checkout of a repo carrying a campaign is the `orchestrator`. No
+  campaign is `solo`, said out loud rather than implied. There is no writable state that changes
+  the answer, which is the entire point of cause 3.
+- **The announcement carries the content, not a pointer to it.** Telling a session to go read a
+  file is the same bet that just lost.
+
+And a companion PreToolUse guard on **Bash** refusing raw `claude -p` from the orchestrator seat,
+because the competing path is one line and needs to cost something. **No env-var override**: an
+override the agent can set is cause 3 again, and it gets set at the moment the agent is most stuck.
+The refusal prints the two legitimate routes instead — `spawn --launch` for work, the Agent tool
+for read-only fan-out — both cheaper than what was refused.
+
+**Stated limit.** Hooks are read at session start, so registering this cannot protect the session
+that registers it. `doctor` reports the registration separately for the same reason it does for the
+worktree-guard shim.
+
+**What is still inert, measured on a real consumer.** `roles.claim()` is lock-backed, campaign-scoped
+and carries liveness — and nothing calls it. There is no CLI verb, and `_resolved` says so in its own
+docstring: *"Assignment has no writer yet."* So every session resolves to the fallback, which is
+fail-closed and correct and is also the whole policy collapsed onto one seat. `spawn` still passes the
+dispatch guard from there, so an orchestrator can work; it is the role *model* that is inert, not the
+tool (#42).
+
+**And the identity layers have nowhere to live.** `FIELDS` covers the mechanism — acquire, capacity,
+reports_to, may_create, writes, notes — and an unknown key warns rather than rejecting, so nothing
+breaks. But there is no per-role `description` and no top-level `charter`: prose true of *every* role,
+announced to all of them. A consumer's standing mandate is exactly that shape, and theirs survived
+nine days only because each compaction summary happened to re-quote it. One summary that compressed
+it away and it was gone with nothing able to notice — the same class of failure this section exists
+for, one level up (#42).
+
+---
 
 ## Isolation is per-resource; a worktree is not a boundary
 
-A worktree isolates **tracked files** and nothing else. Everything resolved from an absolute path or
-from a hook's own script location stays shared, so the audit at spawn enumerates what a Crawler
-actually gets rather than letting "it has its own worktree" stand in for independence.
+A worktree isolates **tracked files** and nothing else. Anything resolved from an absolute path,
+or from a hook's own script location, stays shared — so the audit at spawn enumerates what a
+Crawler actually gets rather than letting "it has its own worktree" stand in for independence.
 
 **Corrected on re-reading the harness (2026-08).** showrunner originally recorded, from issue #13,
-that a commit made inside a worktree is gated on the **main checkout's** verification record. That is
-no longer true of current game_loop and the claim is retracted. `guard-writes-impl.sh` resolves the
-commit gate from the **tree the commit targets**: it reads the `git commit`'s `-C`/cwd, and when that
-resolves to a different tree nested inside the project it uses *that* tree's `.game_loop`. If the
-target tree carries no harness it **denies**, on the stated grounds that reading another tree's record
-would answer a question about files this commit does not contain. `TARGET_TREE` scopes the
-blast-radius check's index the same way. Both of issue #13's consequences — the throughput one and the
-serious correctness one — are handled there.
+that a commit made inside a worktree is gated on the **main checkout's** verification record. That
+is no longer true of current game_loop and the claim is retracted: `guard-writes-impl.sh` resolves
+the commit gate from the tree the commit *targets*, reading the `git commit`'s `-C`/cwd, and when
+that resolves to a different tree nested in the project it uses *that* tree's `.game_loop`. If the
+target tree carries no harness it **denies**, on the stated grounds that reading another tree's
+record would answer a question about files this commit does not contain.
 
-This is worth recording as more than a footnote, because it is the whole premise-verification argument
-turned on its author: showrunner shipped a paragraph asserting a harness behaviour that the harness had
-already fixed, and only re-reading the source caught it. An orchestrator carrying a stale model of the
-layer below will brief every Crawler with it.
+Worth recording as more than a footnote, because it is premise verification turned on its author:
+showrunner shipped a paragraph asserting a harness behaviour the harness had already fixed, and
+only re-reading the source caught it. An orchestrator carrying a stale model of the layer below
+briefs every Crawler with it.
 
-**What the fix hands back to showrunner** is a new, concrete constraint: each Crawler worktree must
-carry its own harness, or its first commit is denied — and **`git worktree add` copies tracked files
-only**, so a gitignored harness directory never crosses. That is the secret-injection problem (#10)
-with the harness as the missing file, equally invisible at spawn. `worktree.harness_gap()` detects it
-at `spawn` and in `doctor`.
+**What the fix hands back** is a concrete constraint: each Crawler worktree must carry its own
+harness or its first commit is denied — and `git worktree add` copies tracked files only, so a
+gitignored harness directory never crosses. That is the secret-injection problem (#10) with the
+harness as the missing file, equally invisible at spawn. `worktree.harness_gap()` detects it at
+`spawn` and in `doctor`.
+
+The same tracked-vs-ignored split governs the guard shim itself, and there is no third state:
+commit it and git carries it, or keep `.showrunner/` out of history and `spawn` provisions it. A
+shim that is neither cannot be carried *or* provisioned — copying it would hand the Crawler a file
+its own `git add -A` commits onto its branch, colliding with the same untracked path in the main
+checkout — so `doctor` names which arrangement you are in, and warns when you are in neither.
+
+**One session per worktree.** A worktree had an owner on paper in `campaign.json` and no holder in
+fact, and nothing consulted that record when a second session opened the directory and started
+editing. So a lease's holder is a **live process**, and `pid_basis` records how that pid was
+learned, because a hook is handed no PID and the answer comes from walking an ancestry: a lease
+resting on `ppid-fallback` is worth less than one resting on `ancestor-claude`. `enter` never
+blocks — a SessionStart hook cannot — so `enter` is where the prompt lives and `guard` is where the
+enforcement lives. It denies on exactly one condition: HELD by a different live session. FREE,
+STALE and UNREADABLE all allow, and none is an oversight — a stale holder is proved dead, and an
+unreadable one cannot be adjudicated, so refusing on it would wedge a tree on a partial write.
 
 The general lesson stands unchanged: **isolation has to be reasoned about per-resource, not granted
-wholesale by the worktree** — and the per-resource answers can differ, since a harness may deliberately
-scope one thing to the session (the edited-file set: one session is one session however many trees it
-touches) and another to the tree (what a change owes).
+wholesale by the worktree** — and the per-resource answers legitimately differ, since a harness may
+scope one thing to the session (the edited-file set: one session is one session however many trees
+it touches) and another to the tree (what a change owes).
+
+---
+
+## A blocked Crawler needs a message, not time
+
+The state that most needs a human is the one every other signal reads as healthy: a Crawler
+refused at its own turn-end is **alive and inert**. `reap` correctly proposes nothing, the pid is
+live, the exit code is 0, and the artifacts on disk look finished. One sat that way for 44 minutes.
+
+Three adjacent mechanisms all miss it, which is why it needed its own gate:
+
+| | why it does not cover this |
+|---|---|
+| the harness watchdog | fires on *idle*, which is after the orchestrator already stopped |
+| the harness Stop gate | refuses a turn-end that asks a question or claims to be continuing; "I am done for now, here is what is next" is neither |
+| a stall gate | asks "did anything move this turn"; a turn that read files and edited tickets answers yes and still leaves a Crawler inert |
+
+The unmet question is narrower than all three: **is somebody waiting on a message from me.**
+`waiting` already computed it and nothing spent it at the one moment that decides anything, so
+`.showrunner/hooks/inert-crawler-gate.sh` refuses the orchestrator's turn-end while that is true.
+
+Two further lessons came from wiring that gate at all — both from making a documented gate
+*reachable*:
+
+- **Read `--porcelain`, not the prose.** The obvious spelling is `waiting | grep BLOCKED`, and it
+  cannot work: the BLOCKED lines go to **stderr**, and `waiting` exits non-zero precisely when it
+  is *not* waiting, which is the state a blocked Crawler produces. The natural script discards the
+  channel the finding is on and then reads the exit code as "cannot see". Both halves fail toward
+  silence.
+- **`stop-gate --leaf <id>` — the scope is load-bearing.** Unscoped, the gate asks "is *any* leaf
+  open in this campaign", and since the same gate is written into every Crawler's triggers, with N
+  dispatched, N−1 are structurally guaranteed to be refused at least once — each advised to close
+  work in worktrees it cannot reach, and a headless Crawler has no next turn in which to act on it.
+
+Jurisdiction is the other half: the gate does not fire inside a Crawler's own worktree, because a
+Crawler has no channel to its siblings and no authority to reap them, and a gate demanding an
+action its subject cannot take is worse than no gate.
+
+---
 
 ## Premise verification is the highest-leverage line in a brief
 
-Over one real run of 14 issues, three had premises that did not survive contact with the codebase: a
-failure that was not live in that repo, tooling that was asserted to exist and did not, and a command
-from an entirely different harness. That is not a criticism of the issues — a good bug report is
-written from the incident, and the incident happened somewhere.
+Over one run of 14 issues, three had premises that did not survive contact with the codebase: a
+failure not live in that repo, tooling asserted to exist that did not, and a command from an
+entirely different harness. In a later batch of seven, all seven held. **The rate is not the
+point** — you cannot tell which batch you are in from the inside, and the two look identical until
+you read the source.
 
-Why it is a *showrunner* problem specifically: a Crawler that quietly implements a fix for a bug that
-is not there is **indistinguishable** from one that did the work, and the proof-of-done gate is
-satisfied because a real artifact really was produced. The gate checks that work happened, not that it
-was needed. And fan-out makes it worse rather than better — a single agent working a queue serially
-starts noticing that issue 9 contradicts what it read for issue 3; N isolated agents each see one
-issue and cannot notice anything.
+Why this is *showrunner's* problem specifically: a Crawler that quietly implements a fix for a bug
+that is not there is **indistinguishable** from one that did the work, and the proof-of-done gate
+is satisfied because a real artifact really was produced. The gate checks that work happened, not
+that it was needed. And fan-out makes it worse rather than better — one agent working a queue
+serially starts noticing that issue 9 contradicts what it read for issue 3; N isolated agents each
+see one issue and cannot notice anything.
 
-Hence: `--premise` and `--premise-read` are **required arguments of the close**, and `--refuted` is a
-first-class successful outcome. If the only shapes available are done/failed, the incentive is to
-build something.
+Hence `--premise` and `--premise-read` are **required arguments of the close**, and `--refuted` is
+a first-class successful outcome. If the only available shapes are done and failed, the incentive
+is to build something.
+
+Two smaller pieces of the same argument:
+
+- **`--finding` in a brief.** Where the orchestrator has already checked a premise, the brief
+  carries the finding *and its evidence* and asks the Crawler to confirm or refute rather than to
+  trust. An independent confirmation with line numbers is worth strictly more than either reading.
+- **`edit` exists because the body IS the brief.** A leaf's body is interpolated into the document
+  a Crawler works from, so a wrong body dispatches a wrong task — and before `edit` the only exit
+  was closing the leaf, which spends the proof-of-done gate on a decision that never happened. It
+  refuses on a leaf that is not open, so it cannot rewrite instructions under a working Crawler.
+
+---
+
+## Observability: snapshot first, then watch
+
+An event saying `leaf.closed` is not a picture, it is a delta against one. So `snapshot` returns
+the whole world in one call at one instant — ready leaves, in-progress leaves, every Crawler with
+its verdict, every resource with its holder, the waiting verdict — and `watch --since <cursor>`
+returns exactly what is not already reflected in it. Assembling the same thing from
+`status` + `reconcile` + `waiting` + `plan` costs four round trips and yields a composite of
+instants that never co-existed. It is **not** a transaction; what it removes is the four-call
+window, not the milliseconds.
+
+Decisions worth keeping:
+
+- **The cursor names its instance.** A seq counts within one journal, and several showrunners in
+  several repos is the ordinary case, so a bare integer crossing that boundary is a confident
+  answer about a different campaign — both sides integers, the comparison succeeding, nothing able
+  to notice. `--since` refuses a cursor from a different showrunner.
+- **The cursor is the consumer's.** `watch` keeps no durable position. Never record one as proof of
+  delivery before the sink has taken the frames; that turns at-least-once into at-most-once,
+  silently.
+- **Frames carry their own type**, because three kinds of nothing look alike: `ready` ends the
+  replay so attaching is never a blank screen, `heartbeat` proves a sparse stream is alive (an
+  orchestrator can integrate for twenty minutes writing no event), and `bye` marks a clean end — a
+  stream that simply stops did not end, it broke.
+- **`crawler.blocked` is journalled on the transition, not the state.** `reconcile` recomputes it
+  every call, so a poller would otherwise get one identical line per poll.
+- **`lock.refused` is an event.** Without it a contended resource and an idle one draw the same
+  picture, and there is no way to render a queue. `lock.reclaimed` is a reaper taking a resource
+  off a dead holder — not the holder letting go.
+- **Freshness is reported, not assumed.** `reconcile` opens with `checked`, `last re-check` and
+  `next re-check`; `snapshot` carries the same as `follow_up`. A reading taken thirty seconds ago
+  is otherwise indistinguishable from one taken yesterday. And `next re-check` names a **trigger,
+  not a time**, because the watchdog fires on idle and publishes no interval — a clock time there
+  would be a number showrunner invented about an event it does not schedule. With no probe armed
+  it says `NONE SCHEDULED` and why.
+
+Consumers should ask the verbs, not read `.showrunner/events.jsonl`: the file's name and layout are
+showrunner's business, and a consumer reaching past the verb breaks the next time either changes.
+
+---
+
+## The work graph, and why it is vendored
+
+`br ready` was originally described as the only work-discovery entrypoint, which made a Rust
+toolchain and a separate tracker load-bearing for every loop iteration. The layer below reaches as
+far as it does substantially because it has **no install step worth the name**, and showrunner
+inherits that audience; every dependency is a place adoption stops, and this one sat in front of
+the *first* command.
+
+So: a minimal graph over Python's built-in `sqlite3`, plus a `br` adapter preferred when br is
+genuinely present. Both sit behind one `Graph` interface and nothing else learns which backend it
+got (`lib/showrunner/graph.py`).
+
+Two capabilities the vendored backend has that a general tracker does not, because an orchestrator
+needs them:
+
+- **Claims carry liveness** — pid, boot token, worktree, session.
+- **`refuted` is a terminal state**, distinct from `closed`.
+
+The br adapter cannot answer `stale_claims()`, because br records no liveness on a claim, so it
+**raises rather than returning an empty list**. `[]` would read as "nothing is stale", the one
+answer that must never be produced by not knowing.
+
+**Field data, 2026-08.** br 0.2.18 was installed on a consumer machine and its CLI shape confirmed
+first-hand: `br ready` / `blocked` / `coordination status` / `scheduler`, JSON everywhere, and a
+close policy that refuses `update --status closed` so closes carry a reason. It is a good tracker.
+It also left **four claims sitting `in_progress` for a month** in that repo with nothing able to
+tell they were dead — which is the `stale_claims()` gap in the field rather than in theory. That
+consumer has since removed br and pinned the vendored backend. The adapter stays: br is a
+reasonable choice for a human-facing tracker, and the honest framing is that **choosing br costs
+you `reap`**, stated at the point of choice rather than discovered a month later.
+
+---
+
+## Distribution: one copy of the code, every project's own config
+
+Per-project install stays the default and the documented path. Central is opt-in, one flag, and
+reversible in both directions. Under `--central`, `.showrunner/bin/showrunner` stops being the tool
+and becomes ~20 lines of bash that exec a shared copy — machine-agnostic and byte-identical in
+every project, so a consumer who commits it anyway commits nothing about their machine.
+
+**Only the code is shared.** There is no `SHOWRUNNER_HOME` and none is needed: `config.load`
+resolves the project from the cwd's git root, so the central binary run inside a consumer repo — or
+one of its worktrees — reads *that* repo's config, graph and locks.
+
+**`--version` answers with a commit, and resolves it from where the CODE lives, never from the
+cwd.** Under a central install the cwd is some consumer project, so answering from it would report
+that project's HEAD as showrunner's version. Three provenances, and only two can name a commit:
+**pinned** (extracted from a git ref; the strongest, and why central mode can say what every
+project on the machine runs), **checkout** (reports HEAD, and whether the tree is dirty, because
+uncommitted edits make that sha an overstatement), and **copy** (no commit names this code, and
+none is invented — that absence is the argument for pinning). `__version__` alone was `0.1.0` for
+the project's whole life and could not distinguish a checkout from this morning from an install
+three weeks stale.
+
+**When central is missing the fail posture splits.** Hook verbs exit 0 and *say* `ALLOWED WITHOUT
+BEING CHECKED`; every other verb exits 1 naming the populate command. What pinning does **not**
+establish: `VERSION` names what was extracted, not what is there now. Nothing hashes the central
+directory afterwards, so one bad pin reaches every project on the machine at once.
+
+---
+
+## Checks: no new failures, never "all green"
+
+A repo with pre-existing failures cannot satisfy "all green", so that version of the gate gets
+switched off on contact with a real codebase. `baseline` records, `check` compares, and a check
+that fails without producing parseable failure lines degrades to exit-code granularity **and says
+so** — reduced resolution must never read as a clean comparison.
+
+`integration-commit` exists because a provenance check keyed to "did *you* edit this?" answers no
+for every integration commit, correctly: Crawlers wrote the files, `git merge` brought them in. The
+useful question is different — does the staged set match the union of what the merged Crawlers
+edited? — and it catches the real failure: a file in an integration commit that no Crawler touched.
+
+---
+
+## Several orchestrators at once
+
+Supported, and the discipline is one line: do not read `ready` and claim its first entry, because
+everyone gets the same list. `claim --next` takes any free leaf atomically and exits 1 when dry.
+Losing a claim race is not an error; a sibling got there first. Integration and single-consumer
+resources stay exclusive and **refuse rather than queue**, so a refusal there means "someone else
+is mid-merge", not "something broke".
+
+**Do not fan out past what `plan` allows.** Two leaves can be mutually unblocked and still be the
+same edit: the graph models dependencies, not files. A false collision costs one wave of latency; a
+missed one costs a merge conflict in an unattended run with nobody watching.
+
+---
 
 ## Validated primitives
 
-`test/run.py` — 908 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
-loudly. `prototype/` holds the original shell POC (7 assertions run anywhere, 5 skip).
+`test/run.py` — 908 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
+skip loudly, naming the dependency. `prototype/` holds the original shell POC (7 assertions run
+anywhere, 5 skip), kept for the record; `prototype/br_gate.sh` is superseded by
+`lib/showrunner/gates.py`, which parses the graph as JSON instead of splitting records on a literal
+`},{` — a shape change there turned the stop gate into a no-op that reported success (#6).
+
+---
 
 ## Still open
 
-- **Lock completeness / rung.** The PreToolUse guard is only as good as its verb classifier; a rogue
-  raw command escapes it. To reach rung-1 IMPOSSIBLE the lock belongs *inside* the consumer tool
-  **and** in the guard — belt + suspenders. `lock run` is the belt; the guard is the suspenders.
+- **A role cannot be acquired.** The claim machinery exists and has no caller, so the role model is
+  built and unreachable. Until it has a verb, `whoami` tells every session it is the fallback (#42).
+- **`charter` and `description` are unmodelled**, so the layer that says *who you are* before *what
+  you may not do* has to be folded into `notes` by the consumer, duplicated per role (#42).
+- **Lock completeness / rung.** The PreToolUse guard is only as good as its verb classifier; a
+  rogue raw command escapes it. Rung-1 IMPOSSIBLE needs the lock *inside* the consumer tool as
+  well as in the guard. `lock run` is the belt, the guard is the suspenders.
 - **Lock fairness.** `acquire --wait` polls; there is no queue, so a starved waiter can lose
-  repeatedly. Said out loud in `locks.py` because a fairness property nobody stated is one somebody
-  will assume.
-- **Blast-radius estimation is a heuristic.** It reads paths named in the issue plus files mentioning
-  the issue's symbols. It is deliberately conservative, and it will over-serialize on prose-heavy
-  issues (it does exactly that on this repo's own issue list). The fix for that is configuring shared
-  surfaces, not loosening the estimate.
+  repeatedly. Said out loud in `locks.py`, because a fairness property nobody states is one
+  somebody will assume.
+- **Blast-radius estimation is a heuristic.** It reads paths named in the issue plus files
+  mentioning the issue's symbols, is deliberately conservative, and will over-serialize on
+  prose-heavy issues — it does exactly that on this repo's own issue list. The fix is configuring
+  shared surfaces, not loosening the estimate.
 - **Relevance of a proof artifact is unknowable by a string check.** The gate checks existence and
   freshness and records the proof for a reviewer. The boundary is stated in the gate itself.
-- **`br` adapter is written against br's documented CLI shape and exercised only through its refusal
-  paths here** — `br` is not installed on the machine this was built on. It is strict on purpose: it
-  will fail loudly rather than quietly report an empty graph.
+- **`spawn --launch` requires a chat room and nothing enforces that the room is read.** A Crawler
+  refused at its turn-end stays alive and inert, and a message is the only thing that restarts it —
+  so the room is not optional. Whether anyone is *listening* is still a matter of habit.
+
+---
 
 ## Theme
 
-Dungeon Crawler Carl. The crawl is a produced show: **Crawlers** run the rooms, `game_loop` keeps each
-one alive, the graph is the quest log, and the **showrunner** runs the whole production.
+Dungeon Crawler Carl. The crawl is a produced show: **Crawlers** run the rooms, `game_loop` keeps
+each one alive, the graph is the quest log, and the **showrunner** runs the whole production.

--- a/llms.txt
+++ b/llms.txt
@@ -552,7 +552,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 917 assertions; needs only Python 3 + git
+python3 test/run.py        # 918 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 


### PR DESCRIPTION
## Why

Nine commits landed on main and `docs/DESIGN.md` moved by exactly one line — `818 assertions` to
`908`. Five of those commits are features (#36, #37, #39, #40, #41), and the doc still frames
adoption as the open question and names #36/#37 as "the direction". A reader arriving now would take
the newest part of the design as unsolved when it is the part that shipped.

## What

Rewritten rather than patched, because the structure was the problem. The worktree lease, the
inert-crawler gate, observability and the central install had all shipped and none of them appeared
in the design notes at all; the failure-mode table had no row for the one failure whose answer had to
be *built* rather than tightened.

Beyond the reorganisation:

- **Adoption as a design surface**, with the four causes as measured on a real consumer: the seam
  asymmetry, guards that read only their own state, a writable seat file, and a matcher on the wrong
  tool. That last one is the reason this could have been built and still done nothing.
- **The two things still inert, said plainly.** `roles.claim()` is lock-backed and campaign-scoped
  and has no caller; `charter` and `description` have nowhere to live. Both are #42, both discovered
  by migrating a consumer onto this code today rather than by reading it.
- **`br` gets field data instead of a caveat.** The old note said the adapter was "exercised only
  through its refusal paths here — `br` is not installed on the machine this was built on." It is
  installed now: 0.2.18, CLI shape confirmed first-hand, and it left four claims `in_progress` for a
  month with nothing able to tell they were dead. That is `stale_claims()` in the field rather than in
  theory, and it makes the honest framing "choosing br costs you `reap`", stated at the point of
  choice.
- **A retraction kept as a retraction.** The issue-#13 paragraph about commit gating is still marked
  corrected rather than quietly deleted, because it is the premise-verification argument turned on
  its author and that is worth more than a tidy doc.

## Verification

`python3 test/run.py` — the doc is prose, so the suite is unaffected; run to confirm nothing else in
the branch moved. Assertion count in the doc follows main at 908.

## Provenance

Written by a consumer of this tool, not its author, from the outside — which is where the adoption
failure was visible. Every claim about the code is cited to the file it came from, and the two claims
I got wrong on the way (unknown role keys reject rather than warn; `project_name` is not configurable)
are corrected in the text rather than carried.
