### PR TITLE
fix: whoami printed Python reprs in the block whose job is to be readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **908 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **910 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **918 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **920 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -341,7 +341,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 918 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 920 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,7 +115,7 @@ build something.
 
 ## Validated primitives
 
-`test/run.py` — 908 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
+`test/run.py` — 910 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
 loudly. `prototype/` holds the original shell POC (7 assertions run anywhere, 5 skip).
 
 ## Still open

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -385,7 +385,7 @@ missed one costs a merge conflict in an unattended run with nobody watching.
 
 ## Validated primitives
 
-`test/run.py` — 918 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
+`test/run.py` — 920 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
 skip loudly, naming the dependency. `prototype/` holds the original shell POC (7 assertions run
 anywhere, 5 skip), kept for the record; `prototype/br_gate.sh` is superseded by
 `lib/showrunner/gates.py`, which parses the graph as JSON instead of splitting records on a literal

--- a/lib/showrunner/roles.py
+++ b/lib/showrunner/roles.py
@@ -280,8 +280,21 @@ def enforced_lines(role_def):
     out.append("may dispatch: %s" % (", ".join(may) if may else
                                      "NOTHING — `dispatch guard` refuses a raw `claude -p` from "
                                      "this seat"))
-    if d.get("writes"):
-        out.append("writes: %s" % d["writes"])
+    w = d.get("writes")
+    # This printed `writes: {'deny': ['**']}` — a Python repr in the block whose entire job is to
+    # be the readable, generated statement of what a guard enforces. Rendered per shape rather
+    # than assumed: the suite's fixture is a LIST of allowed globs, and a consumer may reasonably
+    # hand a mapping. Anything else is printed as-is rather than crashed on, because a renderer
+    # that raises takes the whole announcement down and silence is the one unacceptable outcome.
+    if isinstance(w, (list, tuple)) and w:
+        out.append("may write: %s" % ", ".join(str(x) for x in w))
+    elif isinstance(w, dict):
+        if w.get("deny"):
+            out.append("may NOT write: %s" % ", ".join(str(x) for x in w["deny"]))
+        if w.get("allow") and not w.get("deny"):
+            out.append("may write: %s" % ", ".join(str(x) for x in w["allow"]))
+    elif w:
+        out.append("writes: %s" % w)
     if d.get("reports_to"):
         out.append("reports to: %s" % d["reports_to"])
     if d.get("acquire"):
@@ -354,7 +367,12 @@ def whoami(cfg, session=None):
             out.append("    ENFORCED  " + line)
         notes = (defs.get(role) or {}).get("notes")
         if notes:
-            out.append("    note      %s" % notes)
+            # `%s` on a list prints a Python repr on one line, so a multi-line note arrives as an
+            # unreadable wall — and an announcement nobody can read is one that did not happen.
+            # A string stays one line; a list becomes lines.
+            out.append("    note")
+            for line in ([notes] if isinstance(notes, str) else notes):
+                out.append("      " + str(line))
             out.append("    ...which is prose your project wrote. Nothing checks it.")
     else:
         out.append("  no roles are defined, so no dispatch policy is enforced for any seat.")

--- a/llms.txt
+++ b/llms.txt
@@ -552,7 +552,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 918 assertions; needs only Python 3 + git
+python3 test/run.py        # 920 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -442,7 +442,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 908 assertions; needs only Python 3 + git
+python3 test/run.py        # 910 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/test/run.py
+++ b/test/run.py
@@ -3051,6 +3051,19 @@ def test_seat_and_whoami():
     # `or [""]` so a producer that stopped producing FAILS this rather than raising out of the
     # group — an IndexError here made the mutant unscoreable and the sweep reported a floor from
     # a truncated run as though it were coverage.
+    # A REPR IS NOT A RENDERING. `writes` reached this block through `%s`, so a mapping printed
+    # as `{'deny': ['**']}` and a list as `['src/**']` — Python syntax in the one block whose job
+    # is to state plainly what a guard enforces. Both shapes are asserted because the suite's own
+    # fixture is a list and a consumer may reasonably hand a mapping; neither may render as code,
+    # and neither may raise, since a renderer that raises takes the whole announcement down.
+    listed = R.enforced_lines({"acquire": "claim", "writes": ["src/**", "docs/**"]})
+    ok("a `writes` LIST renders as paths a reader can act on, not as a Python literal",
+       any("src/**, docs/**" in l for l in listed) and not any("[" in l for l in listed), listed)
+    mapped = R.enforced_lines({"acquire": "claim", "writes": {"deny": ["app/**", "backend/**"]}})
+    ok("a `writes` MAPPING renders its denials in words, and does not leak brace syntax",
+       any("may NOT write: app/**, backend/**" in l for l in mapped)
+       and not any("{" in l for l in mapped), mapped)
+
     none_line = (R.enforced_lines({"acquire": "claim"}) or [""])[0]
     ok("a role that may create NOTHING says so in the terms the guard will use, rather than "
        "omitting the line and leaving the reader to infer permission",


### PR DESCRIPTION
## What

`whoami` printed Python reprs in the block whose entire job is to be readable.

    note      ['A session with no established role...', '--- who we are ---', 'We do world-first...
    ENFORCED  writes: {'deny': ['**']}

`notes` went through `%s` on a list, so a multi-line note arrived as one line of literal. `writes`
did the same with its value. Both sit in the output #36 argues *is* the mechanism — a SessionStart
hook cannot block, so what it prints is all it does — and an announcement nobody can read is one
that did not happen.

Found by carrying a real charter through it: eleven lines of standing mandate, announced to every
role, rendered as a single unreadable line. The feature worked and the point of it did not survive.

## Fixes

- **notes** — a string stays one line, a list becomes lines.
- **writes** — rendered per shape rather than assumed. My first attempt assumed a mapping and
  crashed `test_seat_and_whoami` with `'list' object has no attribute 'get'`, because the suite's
  own fixture is `"writes": ["src/**"]` — a list of allowed globs, which is your schema and not the
  one my consumer config had invented. It now renders a list, renders a mapping's allow/deny, and
  falls back to printing anything else rather than raising, since a renderer that raises takes the
  whole announcement down and silence is the one unacceptable outcome.

## Tests

Two assertions, both **mutation-proven** — renderer reverted, both go red; restored, both go green:

    FAIL  a `writes` LIST renders as paths a reader can act on, not as a Python literal
    FAIL  a `writes` MAPPING renders its denials in words, and does not leak brace syntax

## Verification

On your own gate — no NEW failures, never all-green:

| | passed | failed |
|---|---|---|
| baseline `ec41b49`, clean `XDG_CONFIG_HOME` | 818 | 2 |
| this branch, clean `XDG_CONFIG_HOME` | 910 | 2 |

The two are the same two, neither new: the `br` adapter check (needs a beads workspace) and the
doc-count check. Counts in README, llms.txt and DESIGN.md move 908 → 910 for the two added.

## Two findings I did not fix, because they are yours to decide

**The doc-count check is self-referential and environment-sensitive.** It compares the claimed
number against a total that includes failures, so any optional-tooling failure makes it fail — and
editing the claim changes what the run reports, so there is no fixed point to reach from outside.
It fails on baseline too. Reporting rather than touching it.

**`writes` is an allow-list and cannot express a denial.** A campaign lead that may write anything
*except* `app/**` is not expressible as a list of globs, so a consumer wanting deny semantics has
to enforce it themselves — which is what I do, in a separate guard, and it means the announced line
and the enforced rule come from two places again. That is the exact split #40 set out to close, so
it may be worth a shape decision rather than a workaround.

## Note on ordering

This touches the same `DESIGN.md` assertion-count line as #43. Whichever lands first, I will rebase
the other.
