### PR TITLE
fix: every role that used `assign` resolved to the fallback, so a Crawler was write-denied in its own worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **917 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **930 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -239,6 +239,19 @@ refuses a configuration that cannot resolve: a dangling `reports_to`, a cycle, a
 root, nothing claimable at all, or a fallback role that may create something. Definitions live at
 a user-level path, because an in-repo config is writable by the very session it constrains.
 
+**A seat with no role is a guard that gets routed around.** `assign` had no reader, so every
+Crawler resolved to the fallback and ran under the fallback's policy *inside the worktree `spawn`
+had just made for it* — with a deny-everything fallback, an audit leaf finished only by routing
+its evidence around the write guard with shell redirection. `seat_roles` maps a derived seat onto
+one of your roles, `{"seat_roles": {"crawler": "worker"}}`, and the campaign record is the
+assignment being read back: `spawn` names the tree's leaf before the session exists. User level
+wins and a project may only map a seat the user left unmapped — one that could remap its own seat
+would hand itself any role in the catalog. Only a worktree the record NAMES resolves, so `git
+worktree add` grants nothing, and **`orchestrator` ships unmapped on purpose**: standing in the
+main checkout is a location, not a record, and authority by location is the failure this seam
+replaced. `doctor` refuses a seat mapped at a role nothing defines — that seat resolves to the
+fallback, so one typo buys the whole write denial back and nothing else would have said so.
+
 **A campaign is smaller than a repo.** The natural unit of a body of work is often a story, and
 the handoff a showrunner charges is only paid for by the parallelism it buys — so several
 campaigns in one checkout is the ordinary case. `SHOWRUNNER_CAMPAIGN` scopes graph, record, events
@@ -341,7 +354,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 917 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 930 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **920 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **932 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -354,7 +354,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 920 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 932 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -395,7 +395,7 @@ missed one costs a merge conflict in an unattended run with nobody watching.
 
 ## Validated primitives
 
-`test/run.py` — 920 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
+`test/run.py` — 932 assertions, Python 3 + git, no other setup. Assertions needing `br` or `tmux`
 skip loudly, naming the dependency. `prototype/` holds the original shell POC (7 assertions run
 anywhere, 5 skip), kept for the record; `prototype/br_gate.sh` is superseded by
 `lib/showrunner/gates.py`, which parses the graph as JSON instead of splitting records on a literal

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,7 +115,7 @@ build something.
 
 ## Validated primitives
 
-`test/run.py` — 917 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
+`test/run.py` — 930 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
 loudly. `prototype/` holds the original shell POC (7 assertions run anywhere, 5 skip).
 
 ## Still open

--- a/lib/showrunner/cli.py
+++ b/lib/showrunner/cli.py
@@ -233,6 +233,18 @@ def cmd_doctor(args):
     role_defs, role_problems = roles.spec(cfg)
     for msg in role_problems:
         print("  %s %s" % (YEL + "warn " + OFF, msg))
+    # A SEAT MAPPED AT A ROLE NOBODY DEFINED resolves to the fallback, which is indistinguishable
+    # from having written no mapping at all. One typo would otherwise buy back the whole bug this
+    # map exists to fix, and buy it back silently.
+    seat_map, seat_problems = roles.seat_roles(cfg)
+    for msg in seat_problems:
+        print("  %s %s" % (YEL + "warn " + OFF, msg))
+    for where, role in sorted(seat_map.items()):
+        if role_defs and role not in role_defs:
+            print("  %s seat_roles maps the %s seat to %r, which no role defines — that seat "
+                  "resolves to %s and nothing else would have said so"
+                  % (RED + "ERROR" + OFF, where, role, roles.FALLBACK))
+            bad += 1
     for level, msg in roles.validate(role_defs):
         mark = {"error": RED + "ERROR" + OFF, "warn": YEL + "warn " + OFF,
                 "ok": GRN + "ok   " + OFF}[level]

--- a/lib/showrunner/roles.py
+++ b/lib/showrunner/roles.py
@@ -33,8 +33,10 @@ the very session they constrain — the same defect as a seat file a session can
 path outside every allow_write_root is denied and needs an explicit human authorization to change,
 which is the right bar for a policy about what a session may do.
 
-    ~/.config/showrunner/roles.json     authoritative
-    .showrunner/config.json  "roles"    a project may ADD a role, never redefine one
+    ~/.config/showrunner/roles.json          authoritative
+    .showrunner/config.json  "roles"         a project may ADD a role, never redefine one
+    ...either file's "seat_roles"            {seat: role} — a project may map a seat the user
+                                             left unmapped, never REMAP one, for the same reason
 
 Note for other setups: `~/.claude` is an allow_write_root on a default install and is therefore
 NOT such a path, even though it is denied in this checkout.
@@ -60,6 +62,11 @@ ACQUIRE = ("claim", "assign")
 
 # The shape of a role, and the whole vocabulary showrunner has for one.
 FIELDS = ("acquire", "capacity", "reports_to", "may_create", "writes", "notes")
+
+# The one seat whose assignment showrunner already records. Kept as config rather than code for
+# the same reason the roles themselves are: a taxonomy in the tool is a taxonomy its consumers
+# have to argue with.
+SEAT_ROLES_KEY = "seat_roles"
 
 
 def _read(path):
@@ -104,6 +111,47 @@ def spec(cfg):
                 continue
             roles[name] = d
     return roles, problems
+
+
+def _read_seat_roles(path):
+    """({seat: role}, problem). A missing file or a missing map is not a problem."""
+    if not os.path.exists(path):
+        return {}, None
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        return {}, "%s could not be read (%s)" % (path, exc)
+    if not isinstance(data, dict):
+        return {}, None
+    m = data.get(SEAT_ROLES_KEY) or {}
+    if not isinstance(m, dict):
+        return {}, "%s has a %r that is not a JSON object, so no seat resolves through it" % (
+            path, SEAT_ROLES_KEY)
+    return dict((str(k), str(v)) for k, v in m.items()), None
+
+
+def seat_roles(cfg):
+    """Merged {seat: role}. Returns (map, problems).
+
+    USER LEVEL IS AUTHORITATIVE AND A PROJECT MAY ONLY ADD, exactly as for the definitions. A
+    project that could remap its own seat would hand itself any role in the catalog, which is the
+    widening the definitions left the repo to prevent.
+    """
+    m, err = _read_seat_roles(USER_PATH)
+    problems = [err] if err else []
+    m = dict(m)
+    project = (cfg.get(SEAT_ROLES_KEY) or {}) if hasattr(cfg, "get") else {}
+    if isinstance(project, dict):
+        for where, role in project.items():
+            if str(where) in m:
+                problems.append(
+                    "the seat %r is mapped in this project AND at user level; the user-level "
+                    "mapping wins. A project may map a seat the user left unmapped, never remap "
+                    "one." % where)
+                continue
+            m[str(where)] = str(role)
+    return m, problems
 
 
 def validate(roles):
@@ -217,6 +265,30 @@ def claim(cfg, role, session, pid, who=None, seat=0):
 CRAWLER, ORCHESTRATOR, SOLO, UNKNOWN = "crawler", "orchestrator", "solo", "unknown"
 
 
+def crawler_leaf(cfg):
+    """The leaf the campaign record names for THIS worktree, or None. Never raises.
+
+    Its own function because the distinction it draws is load-bearing for policy and not only for
+    the announcement: a worktree `spawn` placed is a record showrunner wrote BEFORE the session
+    existed, and a worktree somebody added by hand is not. Only the former may resolve to a
+    working role -- otherwise `git worktree add` is a way to grant yourself one.
+    """
+    from .util import run
+    from . import campaign as _campaign
+
+    rc, top, _ = run(["git", "rev-parse", "--show-toplevel"], cwd=os.getcwd())
+    if rc != 0 or not (top or "").strip():
+        return None
+    here = os.path.basename(os.path.realpath(top.strip()))
+    try:
+        for c in (_campaign.load(cfg).get("crawlers") or []):
+            if c.get("crawler") == here:
+                return c.get("leaf")
+    except Exception:                                           # noqa: BLE001
+        return None
+    return None
+
+
 def seat(cfg):
     """Where this session STANDS. Returns (seat, evidence). Never raises.
 
@@ -239,15 +311,7 @@ def seat(cfg):
         common if os.path.isabs(common) else os.path.join(os.getcwd(), common)))
 
     if os.path.realpath(top) != main:
-        leaf = None
-        try:
-            here = os.path.basename(os.path.realpath(top))
-            for c in (_campaign.load(cfg).get("crawlers") or []):
-                if c.get("crawler") == here:
-                    leaf = c.get("leaf")
-                    break
-        except Exception:                                       # noqa: BLE001
-            leaf = None
+        leaf = crawler_leaf(cfg)
         return CRAWLER, ("standing in a linked worktree (%s)%s"
                          % (os.path.basename(top),
                             "; the campaign record names its leaf %s" % leaf if leaf else
@@ -350,6 +414,11 @@ def whoami(cfg, session=None):
     elif defs:
         role, how = _resolved(cfg, session, defs)
         out.append("  role: %s (%s)" % (role, how))
+        # A MAPPING THAT WAS DROPPED is announced next to the role it did not produce. Silently
+        # falling back is how a session ends up told it is `unassigned` while a file it cannot
+        # see says otherwise, with nothing connecting the two.
+        for msg in seat_roles(cfg)[1]:
+            out.append("  SEAT MAPPING IGNORED: %s" % msg)
         for line in enforced_lines(defs.get(role)):
             out.append("    ENFORCED  " + line)
         notes = (defs.get(role) or {}).get("notes")
@@ -362,9 +431,39 @@ def whoami(cfg, session=None):
 
 
 def _resolved(cfg, session, defs):
-    """(role, how) — a held claim, else the fallback. Assignment has no writer yet (#40)."""
+    """(role, how) — a held claim, else a seat the campaign record vouches for, else the fallback.
+
+    `assign` never had a writer (#40), so every Crawler resolved to the fallback and ran under the
+    fallback's policy INSIDE the worktree spawn had just made for it. With a deny-everything
+    fallback that is not a safe default, it is a broken tool: an audit leaf finished only by
+    routing its evidence around the guard with shell redirection, and a leaf that had to edit code
+    would have been stopped outright. A guard whose reward for holding is a workaround teaches
+    every later session to route around it.
+
+    The campaign record IS the assignment. `spawn` writes the tree's leaf into it before the
+    session exists, keyed to its worktree — which is what `assign` was specified to mean. So the
+    seat is not a second source of truth being invented here; it is the one showrunner already
+    kept, finally read.
+
+    Deliberately NOT symmetric: a seat resolves only through a mapping the user wrote, and
+    mapping `orchestrator` is left to them precisely because standing in the main checkout is a
+    location, not a record. Authority by location is what put a `lead` in every session that
+    happened to be in the right directory.
+    """
     for entry in roster(cfg):
         holder = entry.get("holder") or {}
         if entry.get("state") == locks.HELD and holder.get("session") == session:
             return holder.get("role") or entry["role"], "claimed"
+
+    mapped, _problems = seat_roles(cfg)
+    if mapped:
+        where, _why = seat(cfg)
+        role = mapped.get(where)
+        if role in defs:
+            if where != CRAWLER:
+                return role, "mapped from the %s seat" % where
+            leaf = crawler_leaf(cfg)
+            if leaf:
+                return role, ("assigned by the campaign record, which names this worktree's "
+                              "leaf %s" % leaf)
     return FALLBACK, "fallback — nothing assigned or claimed this session"

--- a/llms.txt
+++ b/llms.txt
@@ -264,12 +264,34 @@ distinction was never about names — it was about how the seat is obtained:
 | | |
 |---|---|
 | `claim` | a session TAKES an open seat. Exclusive, first-come, with pid+boot liveness so a dead holder's seat is reclaimable. The only way a from-scratch session can get one. |
-| `assign` | written by whoever CREATED the session, before it existed. A session holding one cannot claim. **Nothing writes assignments yet** — `spawn` records no role — so today every session resolves through a claim or the fallback. |
+| `assign` | written by whoever CREATED the session, before it existed. A session holding one cannot claim. The campaign record IS that writing: `spawn` names the tree's leaf before the session exists, keyed to its worktree, and `seat_roles` is what reads it back. |
+
+`seat_roles` maps a **derived seat** onto one of your roles. Without it `assign` had no reader, so
+every Crawler resolved to the fallback and ran under the fallback's policy *inside the worktree
+`spawn` had just made for it* — with a deny-everything fallback, an audit leaf finished only by
+routing its evidence around the write guard with shell redirection. A guard whose reward for
+holding is a workaround teaches every later session to route around it.
+
+```json
+{"roles": {"...": {}}, "seat_roles": {"crawler": "worker"}}
+```
+
+Same authority as the definitions: **user level wins**, and a project may map a seat the user left
+unmapped but never remap one — a project that could remap its own seat would hand itself any role
+in the catalog, which is the widening the definitions left the repo to prevent. A conflict is
+reported, not resolved silently.
+
+Two halves keep this record-based rather than location-based. Only a worktree the campaign record
+NAMES resolves, so `git worktree add` is not a way to grant yourself a role. And **`orchestrator`
+ships unmapped on purpose** — standing in the main checkout is a location, not a record, and
+authority by location is the failure this whole seam replaced. Map it yourself if you want it.
 
 Fields showrunner checks: `acquire`, `capacity`, `reports_to`, `may_create`, `writes`. `notes` is
 your prose and is announced as explicitly unchecked. `doctor` refuses a dangling `reports_to` or
-`may_create`, a `reports_to` cycle, an org with no root, nothing claimable at all, and a fallback
-role that may create something — which would make the fallback a way around the policy.
+`may_create`, a `reports_to` cycle, an org with no root, nothing claimable at all, a fallback
+role that may create something — which would make the fallback a way around the policy — and a
+`seat_roles` entry pointing at a role nothing defines, because that seat resolves to the fallback
+and one typo would otherwise buy the whole write denial back, silently.
 
 **With no roles defined, no dispatch policy is enforced for anybody.** That is deliberate:
 inventing one would refuse the dispatches of every consumer who never wrote any.
@@ -552,7 +574,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 917 assertions; needs only Python 3 + git
+python3 test/run.py        # 930 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -574,7 +574,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 920 assertions; needs only Python 3 + git
+python3 test/run.py        # 932 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/test/run.py
+++ b/test/run.py
@@ -3078,6 +3078,111 @@ def test_seat_and_whoami():
         R.USER_PATH = orig
 
 
+def test_crawler_seat_resolves_to_a_role():
+    group("A Crawler spawn placed is not write-denied in the worktree made for it (#40)")
+    from showrunner import roles as R
+
+    cfg = make_repo()
+    g = new_graph(cfg)
+    g.add("work", leaf_id="c1", labels=["backend"])
+    rec = worktree.spawn(cfg, g.show("c1"), actor="crawler-c")
+    campaign.record_spawn(cfg, rec, pid=os.getpid())
+
+    home = tmpdir("seat-roles-home")
+    os.makedirs(os.path.join(home, "showrunner"), exist_ok=True)
+    rp = os.path.join(home, "showrunner", "roles.json")
+    ROLES = {"campaign-lead": {"acquire": "claim", "capacity": 1, "may_create": ["worker"]},
+             "worker": {"acquire": "assign", "reports_to": "campaign-lead",
+                        "writes": {"allow": ["**"]}},
+             R.FALLBACK: {"acquire": "claim", "writes": {"deny": ["**"]}}}
+
+    def write(seat_map):
+        body = {"roles": ROLES}
+        if seat_map is not None:
+            body["seat_roles"] = seat_map
+        with open(rp, "w") as fh:
+            json.dump(body, fh)
+
+    orig, cwd = R.USER_PATH, os.getcwd()
+    R.USER_PATH = rp
+    try:
+        # THE FIXTURE BEFORE THE READ. `spec` over a file that does not exist yet returns {}, and
+        # `_resolved` refuses a role it cannot find in `defs` — so computing this first made every
+        # fallback assertion below hold no matter what the code did, which is the shape of a test
+        # that certifies the defect it was written to catch.
+        write(None)
+        defs, _ = R.spec(cfg)
+        ok("the fixture's roles are actually loaded, so the fallback assertions below could have "
+           "resolved to `worker` and did not", "worker" in defs, sorted(defs))
+        os.chdir(rec["worktree"])
+
+        # THE REGRESSION. Every Crawler resolved to the fallback, whose policy denies writes
+        # everywhere, INSIDE the tree spawn had just made for it to work in. An audit leaf
+        # finished only by routing its evidence around the guard with shell redirection.
+        role_before, how_before = R._resolved(cfg, "sess-c", defs)
+        eq("WITHOUT a mapping the Crawler still resolves to the fallback, so this stays opt-in "
+           "for every consumer who has written none", role_before, R.FALLBACK)
+
+        write({"crawler": "worker"})
+        role, how = R._resolved(cfg, "sess-c", defs)
+        eq("with the seat mapped, the Crawler resolves to the role the USER named for it",
+           role, "worker")
+        ok("...and says it was the campaign record that assigned it, naming the leaf — the "
+           "record spawn wrote before the session existed IS the assignment `assign` meant",
+           "campaign record" in how and "c1" in how, how)
+
+        # A WORKTREE NOBODY RECORDED GRANTS NOTHING, or `git worktree add` is a way to hand
+        # yourself a role. This is the half that keeps the derivation record-based rather than
+        # location-based.
+        hand = os.path.join(tmpdir("hand-rolled-tree"), "wt")
+        rc, _out, _err = util.run(["git", "worktree", "add", "-b", "by-hand", hand],
+                                  cwd=cfg.root)
+        if rc != 0:
+            skip("a hand-added worktree grants nothing", "git worktree add failed")
+        else:
+            os.chdir(hand)
+            eq("a linked worktree NO campaign record names resolves to the fallback even with "
+               "the seat mapped", R._resolved(cfg, "sess-h", defs)[0], R.FALLBACK)
+
+        # AND THE MAIN CHECKOUT IS NOT A CREDENTIAL. Shipping `orchestrator` mapped would put a
+        # lead in every session that happened to be in the right directory, which is the failure
+        # this whole seam replaced.
+        os.chdir(cfg.root)
+        eq("the orchestrator seat is left unmapped, so standing in the main checkout of a repo "
+           "with a campaign confers no role by itself",
+           R._resolved(cfg, "sess-o", defs)[0], R.FALLBACK)
+
+        # A PROJECT MAY NOT REMAP ITS OWN SEAT -- it could otherwise hand itself any role in the
+        # catalog, the widening the definitions left the repo to prevent.
+        merged, problems = R.seat_roles({"seat_roles": {"crawler": "campaign-lead"}})
+        eq("a project remapping a seat the user already mapped loses to the user-level mapping",
+           merged.get("crawler"), "worker")
+        ok("...and the conflict is reported rather than resolved silently",
+           any("user-level" in x for x in problems), problems)
+
+        # A DROPPED MAPPING IS ANNOUNCED, not merely returned. `whoami` is the seam a session
+        # actually reads, and a mapping silently ignored there leaves it told `unassigned` while
+        # a file it cannot see says otherwise.
+        cfg.data["seat_roles"] = {"crawler": "campaign-lead"}
+        os.chdir(rec["worktree"])
+        body = "\n".join(R.whoami(cfg, session="sess-c"))
+        ok("`whoami` says a seat mapping was IGNORED rather than dropping it quietly",
+           "SEAT MAPPING IGNORED" in body, body[-300:])
+        cfg.data.pop("seat_roles", None)
+
+        # A SEAT MAPPED AT A ROLE NOBODY DEFINED resolves to the fallback, which looks exactly
+        # like having written no mapping at all. One typo buys the whole bug back, so `doctor`
+        # refuses rather than leaving it to be discovered as a write denial mid-run.
+        write({"crawler": "wroker"})
+        rc, out, _err = util.run([os.path.join(ROOT, "bin", "showrunner"), "doctor"],
+                                 cwd=cfg.root, env=dict(os.environ, XDG_CONFIG_HOME=home))
+        ok("`doctor` FAILS on a seat mapped at a role no definition provides, naming the seat "
+           "and the typo", rc != 0 and "wroker" in out and "crawler" in out, (rc, out[-400:]))
+    finally:
+        os.chdir(cwd)
+        R.USER_PATH = orig
+
+
 def test_dispatch_guard():
     group("The cheap dispatch path has a gate on it now (#37)")
     from showrunner import roles as R
@@ -5808,6 +5913,10 @@ def test_retracted_doc_claims():
         ("compares every\nrule file **byte-for-byte** against the main checkout",
          "lib/showrunner/harness.py", "showrunner keeps no list of its own",
          "the harness answers which files are rules; showrunner asks and never compares"),
+        ("Nothing writes assignments yet",
+         "lib/showrunner/roles.py", "The campaign record IS the assignment",
+         "`spawn` wrote the assignment all along — keyed to the worktree, before the session "
+         "existed — and `seat_roles` is what finally reads it back"),
     ]
     # WHITESPACE-NORMALISED, because the first version of this scan was VACUOUS and passed. The
     # docs wrap at 96 columns, so "minus the conversation" is stored as "minus the\nconversation"
@@ -6342,7 +6451,8 @@ def main():
                test_integration, test_worktree_lease, test_worktree_guard_from_inside_a_worktree,
                test_self_pin, test_self_vendored_pin, test_roles,
                test_harness_installer_provenance, test_void_run, test_dispatch_guard,
-               test_seat_and_whoami, test_campaign_scoping,
+               test_seat_and_whoami, test_crawler_seat_resolves_to_a_role,
+               test_campaign_scoping,
                test_issue_waker,
                test_central_install,
                test_installer_leaves_no_vendored_copy,


### PR DESCRIPTION
## The defect

Roles declare `acquire: "claim"` or `acquire: "assign"`. Only `claim` was ever implemented — `_resolved()` carried the comment *"Assignment has no writer yet"* and then returned the fallback. So `assign` was a mode you could configure and could not obtain, and **every role using it resolved to the fallback role.**

## The observed consequence

With a deny-everything fallback, that is not a safe default — it is a broken tool. In a consumer's run, a Crawler that `spawn` had just created a worktree for ran **write-denied inside that worktree**. An audit agent completed only by routing its evidence around the write guard with shell redirection. An agent that needed to edit code would have been stopped outright.

That is the expensive part. A guard whose reward for holding is a workaround teaches every later session to route around it, and that lesson outlives the bug.

## The fix

`seat()` already derived `CRAWLER` / `ORCHESTRATOR` / `SOLO` / `UNKNOWN` from facts showrunner keeps — is the cwd a linked worktree, does the campaign record name it. `_resolved()` never consulted it. Now it does, via a new user-level config map:

```json
{"roles": {"worker": {"acquire": "assign", "writes": {"allow": ["**"]}}},
 "seat_roles": {"crawler": "worker"}}
```

The campaign record is what vouches. `spawn` writes the tree's leaf into it **before the session exists**, keyed to its worktree — which is exactly what `assign` was specified to mean. The seat is not a second source of truth being invented here; it is the one showrunner already kept, finally read. `crawler_leaf()` is split out of `seat()` because that lookup is now load-bearing for policy, not only for the announcement.

## The two constraints, and why they exist

**1. Config owns the taxonomy.** `roles.py` already records why hardcoding role names is wrong — it "put a taxonomy in the tool", and a taxonomy in the tool is one its consumers have to argue with. So the seat→role map is config. User level is authoritative and a project may map a seat the user left **unmapped**, never **remap** one — a project that could remap its own seat would hand itself any role in the catalog, which is precisely the widening that moved role definitions out of the repo to begin with. A conflict is reported, not resolved silently.

**2. Record-based, never location-based.** Only a worktree the campaign record *names* resolves to a role — otherwise `git worktree add` becomes a way to grant yourself one. And **`orchestrator` ships unmapped on purpose**: standing in the main checkout is a location, not a record. Authority by location is the failure this whole seam replaced. Map it yourself if you want it.

## Degraded cases made loud

A mapping that is silently dropped resolves to the fallback, which is indistinguishable from having written no mapping at all — one typo buys the entire bug back and nothing says so. So `doctor` now refuses a seat mapped at a role no definition provides, and `whoami` announces a mapping it ignored next to the role it did not produce.

## How the new test was shown to fail

Six claims, one revert each. Every one has a witness that fails:

| mutation | assertion that fails |
|---|---|
| remove the `seat_roles`/`crawler_leaf` consultation from `_resolved` | the two positive assertions — role resolves to `worker`, and `how` names the record + leaf |
| drop the `if leaf:` record check | a hand-added worktree resolves to the fallback |
| let an unmapped seat borrow any mapping in the file | the `orchestrator` seat confers no role |
| let a project remap a user-mapped seat | both conflict assertions |
| silence the `whoami` line | `SEAT MAPPING IGNORED` is announced |
| drop the `doctor` check | `doctor` refuses a seat mapped at an undefined role |

**The test as first written was itself vacuous, and that is worth recording.** It computed `defs` before the fixture roles file existed, so `spec()` returned `{}` and `_resolved()` refused a role it could not find — every fallback assertion held no matter what the code did. A test certifying the defect it was written to catch. The fixture is now written first, and an assertion pins that the roles really loaded, so those three cannot go vacuous again without failing.

## Docs

`llms.txt` claimed *"Nothing writes assignments yet"*. That is now false, so it is corrected and added to the **retracted-claims scan** — this repo's own mechanism for stopping a retracted claim from coming back. `seat_roles` is documented in `README.md` and `llms.txt`; `test/docs_surface.py` tracks verbs, env vars and hooks, so a config key adds no surface it requires, and it still exits 0.

## Suite

**928 passed, 2 failed, 1 skipped**, against a **measured 915 / 3 / 1 baseline on the same machine**.

Both remaining failures are pre-existing and **environment-caused, proven rather than asserted**. Running the same commit with the user config home pointed at an empty dir:

```
$ XDG_CONFIG_HOME=$(mktemp -d) python3 test/run.py
RESULT: 930 passed, 0 failed, 1 skipped
```

This branch is fully green on a clean environment. The failures appear only because this machine has a real `~/.config/showrunner/roles.json`. Two assertions — `[#37] with no roles configured the raw dispatch is ALLOWED` and `[#36] ...says plainly when no roles are defined` — read the **real** user-level `roles.json` instead of monkeypatching `USER_PATH`, so "no roles configured" is false on any machine that actually uses the feature. Both sit *above* the `R.USER_PATH = rp` line in their own tests. Filed as a separate issue rather than folded in here: the fix belongs to those tests, and folding it in would hide whether this change altered them.

The count claimed in `README.md` / `llms.txt` / `docs/DESIGN.md` was also 1 behind before this branch (docs said 917, suite reported 918); all three now say 930. PRs #43 and #44 touch that same line, so expect a conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
