### PR TITLE
fix: the roles seam had no usable entry point, and close read the wrong tree's proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **917 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **930 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -239,6 +239,19 @@ refuses a configuration that cannot resolve: a dangling `reports_to`, a cycle, a
 root, nothing claimable at all, or a fallback role that may create something. Definitions live at
 a user-level path, because an in-repo config is writable by the very session it constrains.
 
+**A seat with no role is a guard that gets routed around.** `assign` had no reader, so every
+Crawler resolved to the fallback and ran under the fallback's policy *inside the worktree `spawn`
+had just made for it* — with a deny-everything fallback, an audit leaf finished only by routing
+its evidence around the write guard with shell redirection. `seat_roles` maps a derived seat onto
+one of your roles, `{"seat_roles": {"crawler": "worker"}}`, and the campaign record is the
+assignment being read back: `spawn` names the tree's leaf before the session exists. User level
+wins and a project may only map a seat the user left unmapped — one that could remap its own seat
+would hand itself any role in the catalog. Only a worktree the record NAMES resolves, so `git
+worktree add` grants nothing, and **`orchestrator` ships unmapped on purpose**: standing in the
+main checkout is a location, not a record, and authority by location is the failure this seam
+replaced. `doctor` refuses a seat mapped at a role nothing defines — that seat resolves to the
+fallback, so one typo buys the whole write denial back and nothing else would have said so.
+
 **A campaign is smaller than a repo.** The natural unit of a body of work is often a story, and
 the handoff a showrunner charges is only paid for by the parallelism it buys — so several
 campaigns in one checkout is the ordinary case. `SHOWRUNNER_CAMPAIGN` scopes graph, record, events
@@ -341,7 +354,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 917 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 930 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ single Crawler can see, and keeps the campaign coherent across sessions.
 > Status: **implemented and self-hosting.** The orchestration loop is real code
 > ([`lib/showrunner/`](lib/showrunner/)), it installs in one line with no packages, and it has been
 > run against its own issue list — see [Dogfooding](#dogfooding-showrunner-on-its-own-issues).
-> `python3 test/run.py` → **930 assertions, no setup beyond Python 3 and git.**
+> `python3 test/run.py` → **962 assertions, no setup beyond Python 3 and git.**
 
 ## Requirements
 
@@ -252,6 +252,34 @@ main checkout is a location, not a record, and authority by location is the fail
 replaced. `doctor` refuses a seat mapped at a role nothing defines — that seat resolves to the
 fallback, so one typo buys the whole write denial back and nothing else would have said so.
 
+**Both acquisition modes had to become reachable before either worked.** `assign` had no reader;
+`claim` had no writer — `roles.claim` was a library function nothing called, and the `claim` verb
+claims a *leaf*. On a stock install every session got the fallback whatever its roles said.
+
+```
+showrunner role claim campaign-lead --who agent-a   # a role declaring acquire=claim
+showrunner role roster                              # every seat, its state, its liveness basis
+showrunner role release campaign-lead
+```
+
+A role declaring `assign` is refused here — its meaning is that whoever created the session
+decided, so claiming it would be self-nomination into a seat the model says cannot be
+self-nominated; `seat_roles` is how that one is obtained. **A claim's pid is discovered, not handed
+over:** liveness is a pid plus a boot token, so a seat keyed to the short-lived process that made
+the call reports success and reads STALE the instant that call returns, and `whoami` announces the
+fallback again. `lock acquire` warns about exactly this; the roles path shared its mechanism and
+not its mitigation. A pid that cannot be resolved is refused rather than recorded, because a claim
+with no liveness is not a weaker claim — it is a lock nothing can ever reclaim.
+
+**A guard cannot consume prose.** `whoami` emitted only prose, so a hook author needing the
+resolved role had no way to ask and reimplemented the resolver — and a copy drifts. One did: when a
+seat learned to resolve through `seat_roles` the copy did not, so the announcement said one role
+while the guard still enforced the deny-everything fallback. `showrunner whoami --porcelain` emits
+the seat, the resolved role, how it resolved, and the `writes`/`may_create`/`reports_to` a guard
+enforces. `whoami` renders that same dict, so the two cannot disagree. Branch on `enforced`; a null
+`role` is not "no restriction", and the porcelain exits non-zero if it could not resolve so a
+parser can fail closed.
+
 **A campaign is smaller than a repo.** The natural unit of a body of work is often a story, and
 the handoff a showrunner charges is only paid for by the parallelism it buys — so several
 campaigns in one checkout is the ordinary case. `SHOWRUNNER_CAMPAIGN` scopes graph, record, events
@@ -354,7 +382,7 @@ gone, and nothing but running it finds them.
 ## Verifying it
 
 ```bash
-python3 test/run.py            # 930 CORE assertions — Python 3 + git, nothing else
+python3 test/run.py            # 962 CORE assertions — Python 3 + git, nothing else
 bash prototype/demo.sh         # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,7 +115,7 @@ build something.
 
 ## Validated primitives
 
-`test/run.py` — 917 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
+`test/run.py` — 930 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
 loudly. `prototype/` holds the original shell POC (7 assertions run anywhere, 5 skip).
 
 ## Still open

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -115,7 +115,7 @@ build something.
 
 ## Validated primitives
 
-`test/run.py` — 930 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
+`test/run.py` — 962 assertions, Python 3 + git, no other setup. The `br`/`tmux` assertions skip
 loudly. `prototype/` holds the original shell POC (7 assertions run anywhere, 5 skip).
 
 ## Still open

--- a/lib/showrunner/cli.py
+++ b/lib/showrunner/cli.py
@@ -233,6 +233,18 @@ def cmd_doctor(args):
     role_defs, role_problems = roles.spec(cfg)
     for msg in role_problems:
         print("  %s %s" % (YEL + "warn " + OFF, msg))
+    # A SEAT MAPPED AT A ROLE NOBODY DEFINED resolves to the fallback, which is indistinguishable
+    # from having written no mapping at all. One typo would otherwise buy back the whole bug this
+    # map exists to fix, and buy it back silently.
+    seat_map, seat_problems = roles.seat_roles(cfg)
+    for msg in seat_problems:
+        print("  %s %s" % (YEL + "warn " + OFF, msg))
+    for where, role in sorted(seat_map.items()):
+        if role_defs and role not in role_defs:
+            print("  %s seat_roles maps the %s seat to %r, which no role defines — that seat "
+                  "resolves to %s and nothing else would have said so"
+                  % (RED + "ERROR" + OFF, where, role, roles.FALLBACK))
+            bad += 1
     for level, msg in roles.validate(role_defs):
         mark = {"error": RED + "ERROR" + OFF, "warn": YEL + "warn " + OFF,
                 "ok": GRN + "ok   " + OFF}[level]

--- a/lib/showrunner/cli.py
+++ b/lib/showrunner/cli.py
@@ -12,7 +12,8 @@ import sys
 
 from . import (__version__, brief, campaign, collide, config, dispatch, events, gates,
                graph as G, harness, lanes, lease, locks, pin, roles, worktree)
-from .util import (Refused, die, eprint, git, now, rel, run, short_session, slug, stamp)
+from .util import (RESOLVED_BASIS, Refused, die, eprint, git, now, rel,
+                   resolve_from_caller, run, short_session, slug, stamp)
 
 BOLD, DIM, RED, GRN, YEL, OFF = "\033[1m", "\033[2m", "\033[31m", "\033[32m", "\033[33m", "\033[0m"
 if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
@@ -883,16 +884,116 @@ def cmd_whoami(args):
     isolation 42 times — because nothing fired at a session boundary, so every compaction
     refreshed the harness that owned those seams and eroded the tool that did not.
     """
+    session = args.session or os.environ.get("SHOWRUNNER_SESSION") or ""
     try:
         cfg = _cfg(args, required=False)
-        lines = roles.whoami(cfg, args.session or os.environ.get("SHOWRUNNER_SESSION") or "")
+        # ONE RESOLVER, TWO RENDERINGS. The porcelain is not a second answer computed a second
+        # way — `roles.whoami` renders the same dict this prints, so a guard reading the JSON and
+        # a human reading the prose cannot be told different things.
+        if getattr(args, "porcelain", False):
+            print(json.dumps(roles.resolution(cfg, session), indent=2, sort_keys=True))
+            return 0
+        lines = roles.whoami(cfg, session)
     except Exception as exc:                                    # noqa: BLE001 — see docstring
+        if getattr(args, "porcelain", False):
+            # A PARSER MUST NOT READ A CRASH AS A PERMISSIVE ANSWER. The prose path prints and
+            # exits 0 because a SessionStart hook cannot block; a guard consuming this has to be
+            # able to fail closed, so this reports the failure in-band AND exits non-zero.
+            print(json.dumps({"version": roles.PORCELAIN_VERSION, "enforced": False,
+                              "role": None, "problems": ["%s: %s" % (type(exc).__name__, exc)]},
+                             indent=2, sort_keys=True))
+            return 1
         print("showrunner: COULD NOT SAY WHAT THIS SESSION IS — %s: %s. That is printed rather "
               "than swallowed: an announcer that fails quietly is indistinguishable from one "
               "that had nothing to say." % (type(exc).__name__, exc))
         return 0
     for line in lines:
         print(line)
+    return 0
+
+
+# ------------------------------------------------------- role seats (claim/release/roster)
+# BOTH ACQUISITION MODES WERE UNREACHABLE FROM THE CLI. `assign` had no reader until a seat could
+# resolve through `seat_roles`; `claim` had no writer at all — `roles.claim` existed as a library
+# function nothing called, and the `claim` verb claims a LEAF. So on a stock install every
+# session resolved to the fallback whatever its roles said, and the only way to seat anything was
+# to import the library and call it from Python.
+def cmd_role_claim(args):
+    cfg = _cfg(args)
+    defs, problems = roles.spec(cfg)
+    for msg in problems:
+        eprint("note: %s" % msg)
+    if not defs:
+        die("no roles are defined, so there is no seat to claim. Define them at %s"
+            % roles.USER_PATH, code=2)
+    if args.role not in defs:
+        die("no role named %r is defined (known: %s)" % (args.role, ", ".join(sorted(defs))),
+            code=2)
+    acquire = (defs[args.role] or {}).get("acquire")
+    if acquire and acquire != "claim":
+        # A ROLE THAT SAYS `assign` MUST NOT BE CLAIMABLE. Its whole meaning is that whoever
+        # created the session decided; letting a session take it here would be self-nomination
+        # into a seat the model says it cannot nominate itself for.
+        die("role %r declares acquire=%r, so it cannot be claimed — it is assigned by whoever "
+            "creates the session, through `seat_roles`" % (args.role, acquire), code=2)
+
+    session = args.session or os.environ.get("SHOWRUNNER_SESSION") or ""
+    ok, holder = roles.claim(cfg, args.role, session, pid=args.pid, who=args.who, seat=args.seat)
+    if not ok and holder.get("pid_basis") == "unresolved":
+        print("showrunner: %s.\n  Nothing was claimed; that is said out loud rather than left to "
+              "look like success." % holder.get("why"))
+        return 1
+    if not ok:
+        eprint("BLOCKED: seat %s#%d is held by pid %s (%s)"
+               % (args.role, args.seat, holder.get("pid"), holder.get("who")))
+        return 1
+    print("CLAIMED %s#%d (pid %s — liveness basis: %s)"
+          % (args.role, args.seat, holder.get("pid"), holder.get("pid_basis") or "?"))
+    if holder.get("pid_basis") != RESOLVED_BASIS:
+        # DEAD ON ARRIVAL IS THE WORST OUTCOME, so it is named at the moment of claiming rather
+        # than discovered later as a fallback role. `lock acquire` prints the same warning for
+        # the same reason; this path shared its mechanism and not its mitigation.
+        eprint("NOTE: liveness rests on %r, not on a resolved session process. If that pid exits, "
+               "this seat reads STALE and `whoami` will announce the fallback again — check with "
+               "`%s role roster`." % (holder.get("pid_basis") or "?", brief.sr_bin(cfg)))
+    return 0
+
+
+def cmd_role_release(args):
+    cfg = _cfg(args)
+    ok, before = roles.release(cfg, args.role, pid=args.pid, seat=args.seat, force=args.force)
+    if not ok:
+        eprint("nothing to release: seat %s#%d is not held" % (args.role, args.seat))
+        return 1
+    print("RELEASED %s#%d (was pid %s — %s)"
+          % (args.role, args.seat, before.get("pid"), before.get("who")))
+    return 0
+
+
+def cmd_role_roster(args):
+    """Every seat and the state of its holder — the read that made a dead claim diagnosable.
+
+    A claim keyed to a process that had already exited reported success and then read STALE, and
+    the only way to SEE that was to call `roles.roster` from Python. A state nothing surfaces is
+    a state nobody debugs.
+    """
+    cfg = _cfg(args)
+    entries = roles.roster(cfg)
+    if args.json:
+        print(json.dumps(entries, indent=2, sort_keys=True))
+        return 0
+    if not entries:
+        print("no role seats have been claimed in this campaign.")
+        return 0
+    for e in entries:
+        h = e.get("holder") or {}
+        print("%-24s %-6s pid %s (%s) basis %s" % (e["role"], e["state"], h.get("pid") or "-",
+                                                   h.get("who") or "-",
+                                                   h.get("pid_basis") or "-"))
+    stale = [e["role"] for e in entries if e["state"] == locks.STALE]
+    if stale:
+        eprint("NOTE: %d seat(s) read STALE — the holder is proved dead, so `_resolved` skips "
+               "them and those sessions announce the fallback: %s" % (len(stale), ", ".join(stale)))
     return 0
 
 
@@ -1436,9 +1537,12 @@ def cmd_amend(args):
     """
     cfg = _cfg(args)
     g = _graph(cfg)
-    path = args.evidence if os.path.isabs(args.evidence) else os.path.join(cfg.root, args.evidence)
+    # SAME JOIN, SAME DEFECT as the close gate had: a session standing in a worktree supplies
+    # this path, so resolving it against the main checkout reads a different file of the same name.
+    path, ev_root = resolve_from_caller(cfg, args.evidence)
     if not os.path.exists(path):
-        die("--evidence names a path that does not exist: %s" % args.evidence, code=2)
+        die("--evidence names a path that does not exist: %s%s"
+            % (args.evidence, "" if not ev_root else " (resolved against %s)" % ev_root), code=2)
     if os.path.isfile(path) and os.path.getsize(path) == 0:
         die("--evidence names an empty file: %s" % args.evidence, code=2)
     before = g.show(args.id)
@@ -2061,7 +2165,41 @@ def build_parser():
                             "never declared, so there is no file a session can write to become "
                             "something else. Register on SessionStart AND PostCompact")
     s.add_argument("--session")
+    s.add_argument("--porcelain", action="store_true",
+                   help="the SAME resolution as data: seat, role, how, and the writes/"
+                        "may_create/reports_to a guard has to enforce. Build a hook against "
+                        "this instead of keeping a copy of the resolver — a copy is a second "
+                        "statement of one policy and it will disagree. Branch on `enforced`; "
+                        "exits non-zero if it could not resolve, so a parser can fail closed")
     s.set_defaults(func=cmd_whoami)
+
+    s = sub.add_parser("role", help="role SEATS — claim one, give it back, or see who holds what. "
+                                    "`claim` claims a LEAF; this claims a role")
+    rsub = s.add_subparsers(dest="rolecmd")
+
+    t = rsub.add_parser("claim", help="take an open seat (only a role declaring acquire=claim)")
+    t.add_argument("role")
+    t.add_argument("--seat", type=int, default=0)
+    t.add_argument("--who")
+    t.add_argument("--session")
+    t.add_argument("--pid", type=int,
+                   help="override the discovered session pid. The default DISCOVERS the "
+                        "long-lived session process, because a seat keyed to a process that "
+                        "exits when this call returns reports success and reads STALE forever "
+                        "after")
+    t.set_defaults(func=cmd_role_claim)
+
+    t = rsub.add_parser("release", help="give a seat back")
+    t.add_argument("role")
+    t.add_argument("--seat", type=int, default=0)
+    t.add_argument("--pid", type=int)
+    t.add_argument("--force", action="store_true")
+    t.set_defaults(func=cmd_role_release)
+
+    t = rsub.add_parser("roster", help="every seat, its state, and the liveness basis of its "
+                                       "holder — STALE is where a dead claim becomes visible")
+    t.add_argument("--json", action="store_true")
+    t.set_defaults(func=cmd_role_roster)
 
     s = sub.add_parser("dispatch",
                        help="the dispatch seam. `dispatch guard` is a PreToolUse hook ON BASH "

--- a/lib/showrunner/gates.py
+++ b/lib/showrunner/gates.py
@@ -29,7 +29,7 @@ import os
 import re
 import time
 
-from .util import Refused, die, git, now, rel, run
+from .util import Refused, die, git, now, rel, resolve_from_caller, run
 
 DEFAULT_FAILURE_PATTERN = (
     r"^(?:FAILED|FAIL|ERROR|E\s)\b.*|"
@@ -78,10 +78,10 @@ def close_gate(cfg, graph, leaf_id, proof, reason, refuted=False, evidence=None,
             "premise against." % leaf_id,
             hint="An unsourced premise verdict is the same wish as an unsourced 'done'.")
     if premise_read:
-        pr = premise_read if os.path.isabs(premise_read) else os.path.join(cfg.root, premise_read)
+        pr, pr_root = resolve_from_caller(cfg, premise_read)
         if not os.path.exists(pr):
             raise Refused("REFUSED to close %s: --premise-read names a path that does not "
-                          "exist: %s" % (leaf_id, premise_read))
+                          "exist: %s%s" % (leaf_id, premise_read, _looked_in(pr_root)))
     artifact = evidence if refuted else proof
     label = "--evidence" if refuted else "--proof"
 
@@ -92,10 +92,10 @@ def close_gate(cfg, graph, leaf_id, proof, reason, refuted=False, evidence=None,
             if not refuted else
             "Name the file you checked the premise against. A refutation is an assertion too.")
 
-    path = artifact if os.path.isabs(artifact) else os.path.join(cfg.root, artifact)
+    path, art_root = resolve_from_caller(cfg, artifact)
     if not os.path.exists(path):
-        raise Refused("REFUSED to close %s: %s names a path that does not exist: %s"
-                      % (leaf_id, label, artifact))
+        raise Refused("REFUSED to close %s: %s names a path that does not exist: %s%s"
+                      % (leaf_id, label, artifact, _looked_in(art_root)))
     if os.path.isfile(path) and os.path.getsize(path) == 0:
         raise Refused("REFUSED to close %s: %s names an empty file: %s" % (leaf_id, label, artifact))
 
@@ -117,8 +117,8 @@ def close_gate(cfg, graph, leaf_id, proof, reason, refuted=False, evidence=None,
                 raise Refused(
                     "REFUSED to close %s: %s (%s) has not changed since before the leaf was "
                     "claimed (artifact %s, claim %s). An artifact older than the work is "
-                    "evidence about something else."
-                    % (leaf_id, label, artifact, _ts(mtime), _ts(claim_ts)),
+                    "evidence about something else. Read from %s."
+                    % (leaf_id, label, artifact, _ts(mtime), _ts(claim_ts), path),
                     hint="If a pre-existing artifact genuinely is the proof (e.g. a test that "
                          "already covered this and now passes for a new reason), say why:\n"
                          "  --stale-proof-reason \"<why this older file proves this work>\"\n"
@@ -143,6 +143,15 @@ def close_gate(cfg, graph, leaf_id, proof, reason, refuted=False, evidence=None,
         "checkable; relevance is not. The proof is recorded on the close so a reviewer can "
         "judge it later — that is the boundary, stated rather than papered over.")
     return graph.show(leaf_id), notes
+
+
+def _looked_in(root):
+    """The tree a relative path was resolved against, or nothing for an absolute one.
+
+    Said in the refusal because the failure it replaces was undiagnosable from the outside: the
+    gate named a path the caller recognised and a verdict about a file it had never seen.
+    """
+    return "" if not root else " (resolved against %s — pass an absolute path to override)" % root
 
 
 def _ts(epoch):

--- a/lib/showrunner/roles.py
+++ b/lib/showrunner/roles.py
@@ -33,8 +33,10 @@ the very session they constrain — the same defect as a seat file a session can
 path outside every allow_write_root is denied and needs an explicit human authorization to change,
 which is the right bar for a policy about what a session may do.
 
-    ~/.config/showrunner/roles.json     authoritative
-    .showrunner/config.json  "roles"    a project may ADD a role, never redefine one
+    ~/.config/showrunner/roles.json          authoritative
+    .showrunner/config.json  "roles"         a project may ADD a role, never redefine one
+    ...either file's "seat_roles"            {seat: role} — a project may map a seat the user
+                                             left unmapped, never REMAP one, for the same reason
 
 Note for other setups: `~/.claude` is an allow_write_root on a default install and is therefore
 NOT such a path, even though it is denied in this checkout.
@@ -60,6 +62,11 @@ ACQUIRE = ("claim", "assign")
 
 # The shape of a role, and the whole vocabulary showrunner has for one.
 FIELDS = ("acquire", "capacity", "reports_to", "may_create", "writes", "notes")
+
+# The one seat whose assignment showrunner already records. Kept as config rather than code for
+# the same reason the roles themselves are: a taxonomy in the tool is a taxonomy its consumers
+# have to argue with.
+SEAT_ROLES_KEY = "seat_roles"
 
 
 def _read(path):
@@ -104,6 +111,47 @@ def spec(cfg):
                 continue
             roles[name] = d
     return roles, problems
+
+
+def _read_seat_roles(path):
+    """({seat: role}, problem). A missing file or a missing map is not a problem."""
+    if not os.path.exists(path):
+        return {}, None
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        return {}, "%s could not be read (%s)" % (path, exc)
+    if not isinstance(data, dict):
+        return {}, None
+    m = data.get(SEAT_ROLES_KEY) or {}
+    if not isinstance(m, dict):
+        return {}, "%s has a %r that is not a JSON object, so no seat resolves through it" % (
+            path, SEAT_ROLES_KEY)
+    return dict((str(k), str(v)) for k, v in m.items()), None
+
+
+def seat_roles(cfg):
+    """Merged {seat: role}. Returns (map, problems).
+
+    USER LEVEL IS AUTHORITATIVE AND A PROJECT MAY ONLY ADD, exactly as for the definitions. A
+    project that could remap its own seat would hand itself any role in the catalog, which is the
+    widening the definitions left the repo to prevent.
+    """
+    m, err = _read_seat_roles(USER_PATH)
+    problems = [err] if err else []
+    m = dict(m)
+    project = (cfg.get(SEAT_ROLES_KEY) or {}) if hasattr(cfg, "get") else {}
+    if isinstance(project, dict):
+        for where, role in project.items():
+            if str(where) in m:
+                problems.append(
+                    "the seat %r is mapped in this project AND at user level; the user-level "
+                    "mapping wins. A project may map a seat the user left unmapped, never remap "
+                    "one." % where)
+                continue
+            m[str(where)] = str(role)
+    return m, problems
 
 
 def validate(roles):
@@ -217,6 +265,30 @@ def claim(cfg, role, session, pid, who=None, seat=0):
 CRAWLER, ORCHESTRATOR, SOLO, UNKNOWN = "crawler", "orchestrator", "solo", "unknown"
 
 
+def crawler_leaf(cfg):
+    """The leaf the campaign record names for THIS worktree, or None. Never raises.
+
+    Its own function because the distinction it draws is load-bearing for policy and not only for
+    the announcement: a worktree `spawn` placed is a record showrunner wrote BEFORE the session
+    existed, and a worktree somebody added by hand is not. Only the former may resolve to a
+    working role -- otherwise `git worktree add` is a way to grant yourself one.
+    """
+    from .util import run
+    from . import campaign as _campaign
+
+    rc, top, _ = run(["git", "rev-parse", "--show-toplevel"], cwd=os.getcwd())
+    if rc != 0 or not (top or "").strip():
+        return None
+    here = os.path.basename(os.path.realpath(top.strip()))
+    try:
+        for c in (_campaign.load(cfg).get("crawlers") or []):
+            if c.get("crawler") == here:
+                return c.get("leaf")
+    except Exception:                                           # noqa: BLE001
+        return None
+    return None
+
+
 def seat(cfg):
     """Where this session STANDS. Returns (seat, evidence). Never raises.
 
@@ -239,15 +311,7 @@ def seat(cfg):
         common if os.path.isabs(common) else os.path.join(os.getcwd(), common)))
 
     if os.path.realpath(top) != main:
-        leaf = None
-        try:
-            here = os.path.basename(os.path.realpath(top))
-            for c in (_campaign.load(cfg).get("crawlers") or []):
-                if c.get("crawler") == here:
-                    leaf = c.get("leaf")
-                    break
-        except Exception:                                       # noqa: BLE001
-            leaf = None
+        leaf = crawler_leaf(cfg)
         return CRAWLER, ("standing in a linked worktree (%s)%s"
                          % (os.path.basename(top),
                             "; the campaign record names its leaf %s" % leaf if leaf else
@@ -350,6 +414,11 @@ def whoami(cfg, session=None):
     elif defs:
         role, how = _resolved(cfg, session, defs)
         out.append("  role: %s (%s)" % (role, how))
+        # A MAPPING THAT WAS DROPPED is announced next to the role it did not produce. Silently
+        # falling back is how a session ends up told it is `unassigned` while a file it cannot
+        # see says otherwise, with nothing connecting the two.
+        for msg in seat_roles(cfg)[1]:
+            out.append("  SEAT MAPPING IGNORED: %s" % msg)
         for line in enforced_lines(defs.get(role)):
             out.append("    ENFORCED  " + line)
         notes = (defs.get(role) or {}).get("notes")
@@ -362,9 +431,39 @@ def whoami(cfg, session=None):
 
 
 def _resolved(cfg, session, defs):
-    """(role, how) — a held claim, else the fallback. Assignment has no writer yet (#40)."""
+    """(role, how) — a held claim, else a seat the campaign record vouches for, else the fallback.
+
+    `assign` never had a writer (#40), so every Crawler resolved to the fallback and ran under the
+    fallback's policy INSIDE the worktree spawn had just made for it. With a deny-everything
+    fallback that is not a safe default, it is a broken tool: an audit leaf finished only by
+    routing its evidence around the guard with shell redirection, and a leaf that had to edit code
+    would have been stopped outright. A guard whose reward for holding is a workaround teaches
+    every later session to route around it.
+
+    The campaign record IS the assignment. `spawn` writes the tree's leaf into it before the
+    session exists, keyed to its worktree — which is what `assign` was specified to mean. So the
+    seat is not a second source of truth being invented here; it is the one showrunner already
+    kept, finally read.
+
+    Deliberately NOT symmetric: a seat resolves only through a mapping the user wrote, and
+    mapping `orchestrator` is left to them precisely because standing in the main checkout is a
+    location, not a record. Authority by location is what put a `lead` in every session that
+    happened to be in the right directory.
+    """
     for entry in roster(cfg):
         holder = entry.get("holder") or {}
         if entry.get("state") == locks.HELD and holder.get("session") == session:
             return holder.get("role") or entry["role"], "claimed"
+
+    mapped, _problems = seat_roles(cfg)
+    if mapped:
+        where, _why = seat(cfg)
+        role = mapped.get(where)
+        if role in defs:
+            if where != CRAWLER:
+                return role, "mapped from the %s seat" % where
+            leaf = crawler_leaf(cfg)
+            if leaf:
+                return role, ("assigned by the campaign record, which names this worktree's "
+                              "leaf %s" % leaf)
     return FALLBACK, "fallback — nothing assigned or claimed this session"

--- a/lib/showrunner/roles.py
+++ b/lib/showrunner/roles.py
@@ -51,7 +51,7 @@ import json
 import os
 
 from . import locks
-from .util import slug
+from .util import session_pid, slug
 
 USER_PATH = os.path.join(
     os.path.expanduser(os.environ.get("XDG_CONFIG_HOME") or "~/.config"),
@@ -67,6 +67,10 @@ FIELDS = ("acquire", "capacity", "reports_to", "may_create", "writes", "notes")
 # the same reason the roles themselves are: a taxonomy in the tool is a taxonomy its consumers
 # have to argue with.
 SEAT_ROLES_KEY = "seat_roles"
+
+# The porcelain contract's version, so a guard parsing it can refuse a shape it does not
+# know rather than silently misread one. Bump it when a field changes meaning.
+PORCELAIN_VERSION = 1
 
 
 def _read(path):
@@ -247,13 +251,52 @@ def roster(cfg):
     return out
 
 
-def claim(cfg, role, session, pid, who=None, seat=0):
-    """Take an open seat. Returns (ok, holder). Exclusivity and liveness come from locks.Lock."""
-    name = "%s#%d" % (slug(role, 40), seat)
-    lock = locks.Lock(_claims_root(cfg), name)
+def _seat_lock(cfg, role, seat):
+    return locks.Lock(_claims_root(cfg), "%s#%d" % (slug(role, 40), seat))
+
+
+def claim(cfg, role, session, pid=None, who=None, seat=0):
+    """Take an open seat. Returns (ok, holder). Exclusivity and liveness come from locks.Lock.
+
+    THE PID IS DISCOVERED, NOT HANDED OVER, when the caller does not supply one — because a
+    claim keyed to a process that exits when the call returns is DEAD ON ARRIVAL. It reports
+    success, and the very next read of the roster says STALE, so `whoami` announces the fallback
+    while the claimer was told `claimed: True`. Reported from a real seating attempt, recovered
+    only by walking the ancestry by hand to find the long-lived session — which is exactly what
+    `util.session_pid` already does, with a `basis` that separates "proved it" from "could not
+    tell". This is the same hazard `lock acquire` warns about in its own output; the roles path
+    shared the mechanism and not the mitigation.
+
+    A pid that cannot be resolved is REFUSED rather than recorded, following `lease`: a claim
+    with no liveness is not a weaker claim, it is a lock nothing can ever reclaim. `pid_basis`
+    travels with the holder so a reader sees which fact the liveness rests on.
+    """
+    basis = "supplied"
+    if pid is None:
+        pid, basis = session_pid()
+        if pid is None:
+            return False, {"pid_basis": basis, "role": role,
+                           "why": "no session process could be resolved, so this claim would "
+                                  "have no liveness at all and was NOT taken"}
+    lock = _seat_lock(cfg, role, seat)
     ok = lock.acquire(pid, who or session or "?", session=session,
-                      extra={"role": role, "seat": str(seat)})
+                      extra={"role": role, "seat": str(seat), "pid_basis": basis})
     return ok, lock.holder()
+
+
+def release(cfg, role, pid=None, seat=0, force=False):
+    """Give a seat back. Returns (ok, holder-before).
+
+    The counterpart `claim` never had, which is why a seat could only be given up by outliving
+    it or by deleting a file. The pid is discovered the same way `claim` discovers it, because
+    `locks.Lock.release` checks the releaser against the recorded holder and the process calling
+    a CLI verb is never the process that was recorded.
+    """
+    lock = _seat_lock(cfg, role, seat)
+    before = lock.holder()
+    if pid is None:
+        pid = session_pid()[0] or os.getpid()
+    return lock.release(pid=pid, force=force), before
 
 
 # ------------------------------------------------------------------- the seat
@@ -388,6 +431,46 @@ _SEAT_MANIFEST = {
 }
 
 
+def resolution(cfg, session=None):
+    """Everything a guard needs in order to enforce, as DATA. Returns a dict.
+
+    THE ANNOUNCEMENT AND THE POLICY COME FROM HERE, both of them. `whoami` renders this and
+    `whoami --porcelain` prints it, so the prose cannot drift from the answer a guard acts on.
+
+    That is not hypothetical tidiness. `whoami` emitted prose and nothing else, so a hook author
+    who needed the resolved role had no way to ask for it and reimplemented the resolver. A
+    consumer's write guard carried such a copy; when a seat learned to resolve through
+    `seat_roles` the copy did not, so the announcement said one role while the guard enforced the
+    deny-everything fallback, and a session was correctly unable to edit the file it had been
+    dispatched to edit. Two statements of one policy, free to disagree — which is the failure
+    `enforced_lines` exists to prevent INSIDE the announcement, arriving from outside it.
+
+    `enforced` is the field to branch on, and it is false whenever showrunner is enforcing
+    nothing — no definitions, or definitions it could not read. A guard must not read a null
+    `role` as "no restriction"; that is the fail-open reading, and `problems` says which it is.
+    """
+    where, evidence = seat(cfg)
+    defs, problems = spec(cfg)
+    role, how = (None, None)
+    if defs and not problems:
+        role, how = _resolved(cfg, session, defs)
+    d = (defs.get(role) or {}) if role else {}
+    return {
+        "version": PORCELAIN_VERSION,
+        "seat": where,
+        "evidence": evidence,
+        "campaign": cfg.campaign,
+        "role": role,
+        "how": how,
+        "enforced": bool(role),
+        "policy": {"writes": d.get("writes"), "may_create": d.get("may_create") or [],
+                   "reports_to": d.get("reports_to"), "acquire": d.get("acquire")},
+        "notes": d.get("notes"),
+        "problems": list(problems),
+        "ignored_seat_mappings": seat_roles(cfg)[1],
+    }
+
+
 def whoami(cfg, session=None):
     """What this session is, what it may do, and what it may not. Returns a list of lines.
 
@@ -398,32 +481,30 @@ def whoami(cfg, session=None):
     from .brief import sr_bin
 
     sr = sr_bin(cfg)
-    where, evidence = seat(cfg)
-    defs, problems = spec(cfg)
+    r = resolution(cfg, session)
+    where = r["seat"]
 
-    out = ["showrunner: you are the %s here." % where.upper(), "  %s." % evidence]
-    if cfg.campaign:
-        out.append("  campaign: %s" % cfg.campaign)
+    out = ["showrunner: you are the %s here." % where.upper(), "  %s." % r["evidence"]]
+    if r["campaign"]:
+        out.append("  campaign: %s" % r["campaign"])
 
     for line in _SEAT_MANIFEST.get(where, []):
         out.append("  " + line.replace("{sr}", sr))
 
-    if problems:
-        out.append("  ROLE DEFINITIONS UNREADABLE: %s" % problems[0])
+    if r["problems"]:
+        out.append("  ROLE DEFINITIONS UNREADABLE: %s" % r["problems"][0])
         out.append("  Nothing below is enforced, and that is said rather than left blank.")
-    elif defs:
-        role, how = _resolved(cfg, session, defs)
-        out.append("  role: %s (%s)" % (role, how))
+    elif r["enforced"]:
+        out.append("  role: %s (%s)" % (r["role"], r["how"]))
         # A MAPPING THAT WAS DROPPED is announced next to the role it did not produce. Silently
         # falling back is how a session ends up told it is `unassigned` while a file it cannot
         # see says otherwise, with nothing connecting the two.
-        for msg in seat_roles(cfg)[1]:
+        for msg in r["ignored_seat_mappings"]:
             out.append("  SEAT MAPPING IGNORED: %s" % msg)
-        for line in enforced_lines(defs.get(role)):
+        for line in enforced_lines(r["policy"]):
             out.append("    ENFORCED  " + line)
-        notes = (defs.get(role) or {}).get("notes")
-        if notes:
-            out.append("    note      %s" % notes)
+        if r["notes"]:
+            out.append("    note      %s" % r["notes"])
             out.append("    ...which is prose your project wrote. Nothing checks it.")
     else:
         out.append("  no roles are defined, so no dispatch policy is enforced for any seat.")

--- a/lib/showrunner/util.py
+++ b/lib/showrunner/util.py
@@ -149,6 +149,9 @@ def pid_alive(pid):
 
 
 SESSION_PROCESS = "claude"
+# The one basis that proves a resolved session process. Named because a caller
+# checking "did this actually resolve?" must not spell it a second time.
+RESOLVED_BASIS = "ancestor-claude"
 MAX_ANCESTRY = 12
 
 
@@ -184,7 +187,7 @@ def session_pid(start=None):
             break
         ppid, comm = parts[0].strip(), os.path.basename(parts[1].strip())
         if comm.startswith(SESSION_PROCESS):
-            return pid, "ancestor-%s" % SESSION_PROCESS
+            return pid, RESOLVED_BASIS
         if first_parent is None:
             first_parent = ppid
         if ppid in ("0", "1"):
@@ -196,6 +199,55 @@ def session_pid(start=None):
     if first_parent and first_parent not in ("0", "1"):
         return int(first_parent), "ppid-fallback"
     return None, "unresolved"
+
+
+def git_common_dir(path):
+    """The shared git dir behind `path`, absolute, or None. Two worktrees of one repo agree here."""
+    rc, out, _ = run(["git", "rev-parse", "--git-common-dir"], cwd=path)
+    out = (out or "").strip()
+    if rc != 0 or not out:
+        return None
+    return os.path.realpath(out if os.path.isabs(out) else os.path.join(path, out))
+
+
+def caller_tree(cwd=None):
+    """The worktree the caller is STANDING IN, or None. Never raises."""
+    rc, top, _ = run(["git", "rev-parse", "--show-toplevel"], cwd=cwd or os.getcwd())
+    top = (top or "").strip()
+    return os.path.realpath(top) if rc == 0 and top else None
+
+
+def resolve_from_caller(cfg, given, cwd=None):
+    """(path, root) for a path a SESSION supplied. Never raises.
+
+    A RELATIVE PATH BELONGS TO THE TREE THE CALLER IS STANDING IN, not to the main checkout.
+    Joining it against `cfg.root` reads a DIFFERENT FILE THAT HAPPENS TO SHARE THE PATH, and the
+    proof gate turned that into its worst possible verdict: an agent working a leaf passed a
+    relative path to a test it had just written in its own worktree, the join found the main
+    checkout's stale copy of the same path, and the close was refused as proof that predates the
+    claim. The proof was real and fresh. The gate read another file and manufactured exactly the
+    verdict it exists to catch, which gives the agent no reason to suspect path resolution.
+
+    Absolute paths were unaffected, so the bug was invisible to anyone who passed those and
+    reliably fatal to anyone who typed the relative path that is natural when you are standing in
+    the directory.
+
+    From the main checkout the caller's tree IS `cfg.root`, so nothing changes there. `root` comes
+    back so a refusal can NAME where it looked — the fix for the confusion is not only resolving
+    correctly, it is saying which tree the answer came from.
+    """
+    if os.path.isabs(given):
+        return given, None
+    root = caller_tree(cwd)
+    # ...BUT ONLY A TREE OF *THIS* REPO. A cwd in some unrelated checkout is not "the tree the
+    # closer is standing in" in any sense the campaign knows about, and silently resolving a
+    # proof path into a stranger repo would be the same class of bug pointed somewhere new. When
+    # the cwd is not ours the answer falls back to `cfg.root`, which is the behaviour that was
+    # always correct for that case.
+    if root and git_common_dir(root) != git_common_dir(cfg.root):
+        root = None
+    root = root or cfg.root
+    return os.path.join(root, given), root
 
 
 def run(cmd, cwd=None, check=False, timeout=None, env=None):

--- a/llms.txt
+++ b/llms.txt
@@ -264,12 +264,34 @@ distinction was never about names — it was about how the seat is obtained:
 | | |
 |---|---|
 | `claim` | a session TAKES an open seat. Exclusive, first-come, with pid+boot liveness so a dead holder's seat is reclaimable. The only way a from-scratch session can get one. |
-| `assign` | written by whoever CREATED the session, before it existed. A session holding one cannot claim. **Nothing writes assignments yet** — `spawn` records no role — so today every session resolves through a claim or the fallback. |
+| `assign` | written by whoever CREATED the session, before it existed. A session holding one cannot claim. The campaign record IS that writing: `spawn` names the tree's leaf before the session exists, keyed to its worktree, and `seat_roles` is what reads it back. |
+
+`seat_roles` maps a **derived seat** onto one of your roles. Without it `assign` had no reader, so
+every Crawler resolved to the fallback and ran under the fallback's policy *inside the worktree
+`spawn` had just made for it* — with a deny-everything fallback, an audit leaf finished only by
+routing its evidence around the write guard with shell redirection. A guard whose reward for
+holding is a workaround teaches every later session to route around it.
+
+```json
+{"roles": {"...": {}}, "seat_roles": {"crawler": "worker"}}
+```
+
+Same authority as the definitions: **user level wins**, and a project may map a seat the user left
+unmapped but never remap one — a project that could remap its own seat would hand itself any role
+in the catalog, which is the widening the definitions left the repo to prevent. A conflict is
+reported, not resolved silently.
+
+Two halves keep this record-based rather than location-based. Only a worktree the campaign record
+NAMES resolves, so `git worktree add` is not a way to grant yourself a role. And **`orchestrator`
+ships unmapped on purpose** — standing in the main checkout is a location, not a record, and
+authority by location is the failure this whole seam replaced. Map it yourself if you want it.
 
 Fields showrunner checks: `acquire`, `capacity`, `reports_to`, `may_create`, `writes`. `notes` is
 your prose and is announced as explicitly unchecked. `doctor` refuses a dangling `reports_to` or
-`may_create`, a `reports_to` cycle, an org with no root, nothing claimable at all, and a fallback
-role that may create something — which would make the fallback a way around the policy.
+`may_create`, a `reports_to` cycle, an org with no root, nothing claimable at all, a fallback
+role that may create something — which would make the fallback a way around the policy — and a
+`seat_roles` entry pointing at a role nothing defines, because that seat resolves to the fallback
+and one typo would otherwise buy the whole write denial back, silently.
 
 **With no roles defined, no dispatch policy is enforced for anybody.** That is deliberate:
 inventing one would refuse the dispatches of every consumer who never wrote any.
@@ -552,7 +574,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 917 assertions; needs only Python 3 + git
+python3 test/run.py        # 930 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -154,6 +154,10 @@ showrunner worktree register         # put ALL FOUR hooks in .claude/settings.js
                                      # the inert-Crawler gate on Stop, and the seat announcement
                                      # on SessionStart AND PostCompact
 showrunner whoami                    # what this session IS — a seat DERIVED from where it stands
+showrunner whoami --porcelain        # the SAME resolution as JSON, for a guard to consume
+showrunner role claim <role>         # take an open seat (a role declaring acquire=claim)
+showrunner role release <role>       # give it back
+showrunner role roster               # every seat, its state, and its holder's liveness basis
 ```
 
 `enter` never blocks — a SessionStart hook cannot — so it is where the *prompt* lives. `guard` is
@@ -296,6 +300,59 @@ and one typo would otherwise buy the whole write denial back, silently.
 **With no roles defined, no dispatch policy is enforced for anybody.** That is deliberate:
 inventing one would refuse the dispatches of every consumer who never wrote any.
 
+### Getting a seat, and keeping it
+
+Both modes had to become reachable before either worked. `assign` had no reader until a seat could
+resolve through `seat_roles`; `claim` had no writer at all — `roles.claim` was a library function
+nothing called, and the `claim` VERB claims a leaf. So on a stock install every session resolved
+to the fallback whatever its roles said.
+
+```
+showrunner role claim campaign-lead --who agent-a
+showrunner role roster
+showrunner role release campaign-lead
+```
+
+`role claim` refuses a role declaring `acquire: "assign"`: its whole meaning is that whoever
+created the session decided, so taking it here would be self-nomination into a seat the model says
+cannot be self-nominated. That one is obtained by `seat_roles`.
+
+**A CLAIM'S PID IS DISCOVERED, NOT HANDED OVER**, and this is the difference between a seat and a
+seat-shaped file. Liveness is a pid plus a boot token, so a claim keyed to the short-lived process
+that *made* the call is dead the moment that call returns: it reports success, the roster reads
+STALE, the resolver skips it, and `whoami` announces the fallback again. Reported from a real
+seating attempt and recovered only by walking the process ancestry by hand — which `util.session_pid`
+already did, with a `basis` separating "proved it" from "could not tell". `lock acquire` prints the
+same warning for the same reason; the roles path shared its mechanism and not its mitigation. A pid
+that cannot be resolved is REFUSED rather than recorded, following `lease`: a claim with no
+liveness is not a weaker claim, it is a lock nothing can ever reclaim.
+
+`role roster` exists because that state had nowhere to be seen. The only way to notice a dead
+claim was calling `roles.roster()` from Python, and a state nothing surfaces is a state nobody
+debugs.
+
+### A guard cannot consume prose
+
+`whoami` emitted prose and nothing else, so a hook author who needed the resolved role had no way
+to ask for it. A consumer's `PreToolUse` write guard therefore carried its own copy of the
+resolver; when a seat learned to resolve through `seat_roles` the copy did not, so the
+announcement said one role while the guard enforced the deny-everything fallback and a session was
+correctly unable to edit the file it had been dispatched to edit. Two statements of one policy,
+free to disagree — the failure `enforced_lines` prevents *inside* the announcement, arriving from
+outside it.
+
+```
+showrunner whoami --porcelain
+```
+
+emits the seat, the evidence, the resolved role and how it was resolved, and the
+`writes`/`may_create`/`reports_to`/`acquire` a guard actually enforces. `whoami` RENDERS this same
+dict, so the prose and the JSON cannot drift. Branch on **`enforced`**: it is false whenever
+showrunner enforces nothing, and a null `role` must never be read as "no restriction" — that is
+the fail-open reading, and `problems` says which case it is. The porcelain exits non-zero if it
+could not resolve at all, so a parser can fail closed; the prose path still exits 0, because a
+SessionStart hook cannot block.
+
 ## The two seams showrunner did not own, and now does
 
 ```
@@ -386,6 +443,13 @@ than your claim*, and unless you state the premise verdict with the file you che
 showrunner close <leaf> --proof <path> --premise holds|partial|refuted|unverifiable \
     --premise-read <path> --reason "<what you did>"
 ```
+
+A RELATIVE PATH IS RESOLVED AGAINST THE TREE YOU ARE STANDING IN, so the artifact you just wrote
+in your own worktree is the one read. It used to be joined against the main checkout, which found
+that checkout's stale copy of the same relative path and refused the close as proof older than the
+claim — the one verdict the gate exists to produce, manufactured from a correct submission, and
+invisible to anyone who happened to pass absolute paths. A cwd outside this repo's trees falls back
+to the main checkout, and a refusal now names the tree it read from.
 
 **4. Write non-repo files in YOUR OWN scratch dir**, the one named in your brief. Commit messages,
 captured output, fixtures, before/after artifacts. Not a shared temp dir. In a real run two Crawlers
@@ -574,7 +638,7 @@ what is there now. Nothing hashes the contents.
 ## Verifying the tool itself
 
 ```
-python3 test/run.py        # 930 assertions; needs only Python 3 + git
+python3 test/run.py        # 962 assertions; needs only Python 3 + git
 bash prototype/demo.sh     # the original shell POC: 7 run anywhere, 5 skip loudly
 ```
 

--- a/test/run.py
+++ b/test/run.py
@@ -3183,6 +3183,263 @@ def test_crawler_seat_resolves_to_a_role():
         R.USER_PATH = orig
 
 
+def test_close_resolves_paths_against_the_callers_tree():
+    group("A relative proof belongs to the tree the closer is standing in, not the main checkout")
+
+    # THE TWO FILES SHARING A PATH ARE THE WHOLE BUG. The main checkout carries a stale copy of
+    # the same relative path, so joining against `cfg.root` finds a real, non-empty, OLD file and
+    # the gate reports the one verdict it exists to catch — proof that predates the claim —
+    # against a file the closer never touched.
+    SHARED = os.path.join("evidence", "witness.txt")
+    cfg = make_repo(files={"README.md": "seed\n", SHARED: "the main checkout's stale copy\n"})
+    stale_in_main = os.path.join(cfg.root, SHARED)
+    long_ago = time.time() - 86400
+    os.utime(stale_in_main, (long_ago, long_ago))
+
+    g = new_graph(cfg)
+    g.add("work", leaf_id="c1", labels=["backend"])
+    rec = worktree.spawn(cfg, g.show("c1"), actor="crawler-c")
+    tree = rec["worktree"]
+
+    def close(leaf_id, proof, premise_read="only-in-this-tree.md"):
+        """The leaf status, or the refusal TEXT. A `Refused` is the finding under test here — the
+        bug is a false refusal — so it is captured and asserted on rather than left to abort the
+        test and hide which assertion the mutation broke."""
+        try:
+            leaf, _notes = gates.close_gate(cfg, g, leaf_id, proof, "done", premise="holds",
+                                            premise_read=premise_read)
+            return leaf["status"]
+        except Refused as exc:
+            return "REFUSED: %s" % exc
+
+    def fresh(leaf_id, rel_path=SHARED):
+        """Claim a leaf, THEN write the artifact, so its mtime is unambiguously after the claim."""
+        g.claim(leaf_id, "crawler-c")
+        full = os.path.join(tree, rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as fh:
+            fh.write("the proof this agent just wrote for %s\n" % leaf_id)
+        return full
+
+    first = fresh("c1")
+    with open(os.path.join(tree, "only-in-this-tree.md"), "w") as fh:
+        fh.write("read to check the premise\n")
+
+    ok("the fixture really does have two files at one relative path, one stale and one fresh, or "
+       "this proves nothing",
+       os.path.exists(stale_in_main) and int(os.path.getmtime(stale_in_main))
+       < int(os.path.getmtime(first)),
+       (int(os.path.getmtime(stale_in_main)), int(os.path.getmtime(first))))
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tree)
+
+        # THE REPORTED FAILURE, ISOLATED. `--premise-read` names a file present in BOTH trees, so
+        # the only thing this can be refused for is the PROOF path — which is the whole point: the
+        # verdict the mis-join manufactured was "proof predates the claim", the one verdict the
+        # gate exists to produce, against a file the closer had never touched.
+        eq("a relative --proof written in the closer's own worktree CLOSES the leaf, instead of "
+           "being refused as proof that predates the claim — the gate was reading the main "
+           "checkout's stale copy of the same path",
+           close("c1", SHARED, premise_read="README.md"), G.CLOSED)
+
+        # THE OTHER HALF: `--premise-read` shared the join, so the file an agent actually read
+        # was reported as not existing when it lived only in the worktree.
+        g.add("more", leaf_id="c2", labels=["backend"])
+        fresh("c2")
+        eq("...so a --premise-read naming a file that exists ONLY in the worktree is accepted "
+           "rather than reported as missing", close("c2", SHARED), G.CLOSED)
+
+        # AN ABSOLUTE PATH ALWAYS WORKED, which is exactly why the bug was invisible to anyone
+        # who passed one and fatal to anyone who typed the relative form.
+        g.add("third", leaf_id="c3", labels=["backend"])
+        abs_proof = fresh("c3")
+        eq("an absolute --proof still closes, so the fix did not trade one form for the other",
+           close("c3", abs_proof, premise_read=os.path.join(tree, "only-in-this-tree.md")),
+           G.CLOSED)
+
+        # AND A GENUINELY STALE PROOF IS STILL REFUSED. Turning a false refusal into a false
+        # acceptance would be strictly worse than the bug.
+        g.add("fourth", leaf_id="c4", labels=["backend"])
+        g.claim("c4", "crawler-c")
+        genuinely_old = os.path.join(tree, "predates.txt")
+        with open(genuinely_old, "w") as fh:
+            fh.write("written before the claim\n")
+        os.utime(genuinely_old, (long_ago, long_ago))
+        ok("a proof in the closer's OWN tree that really does predate the claim is STILL refused "
+           "— the gate was repaired, not disabled",
+           "older than the work" in close("c4", "predates.txt"), close("c4", "predates.txt"))
+
+        # THE REFUSAL NAMES THE TREE IT LOOKED IN. The failure this replaces was undiagnosable
+        # from outside: a path the caller recognised, and a verdict about a file it never saw.
+        g.add("fifth", leaf_id="c5", labels=["backend"])
+        g.claim("c5", "crawler-c")
+        missing = close("c5", "no/such/artifact.txt")
+        ok("a missing relative path says WHICH tree it was resolved against, so the next agent "
+           "to hit this can see the resolution rather than doubting its own artifact",
+           tree in missing and "absolute" in missing, missing[:300])
+    finally:
+        os.chdir(cwd)
+
+    # FROM THE MAIN CHECKOUT NOTHING CHANGES, because there the caller's tree IS cfg.root. That
+    # is what makes this a repair rather than a relocation of the same bug.
+    g.add("sixth", leaf_id="c6", labels=["backend"])
+    g.claim("c6", "orchestrator")
+    with open(os.path.join(cfg.root, "from-main.txt"), "w") as fh:
+        fh.write("closed from the main checkout\n")
+    try:
+        os.chdir(cfg.root)
+        eq("a relative path from the MAIN checkout still resolves there",
+           close("c6", "from-main.txt", premise_read="README.md"), G.CLOSED)
+    finally:
+        os.chdir(cwd)
+
+    # A CWD IN A DIFFERENT REPO IS NOT "THE TREE THE CLOSER IS STANDING IN". Resolving a proof
+    # into a stranger checkout would be this same bug pointed somewhere new, so an unrelated cwd
+    # falls back to `cfg.root` — which was always the right answer for that case.
+    stranger = make_repo(files={"README.md": "a different repo entirely\n"})
+    g.add("seventh", leaf_id="c7", labels=["backend"])
+    g.claim("c7", "orchestrator")
+    with open(os.path.join(cfg.root, "from-main-again.txt"), "w") as fh:
+        fh.write("still the campaign's own checkout\n")
+    try:
+        os.chdir(stranger.root)
+        eq("standing in an UNRELATED repo falls back to the campaign's own checkout rather than "
+           "resolving the proof into a stranger tree",
+           close("c7", "from-main-again.txt", premise_read="README.md"), G.CLOSED)
+    finally:
+        os.chdir(cwd)
+
+
+def test_role_seat_verbs():
+    group("Both acquire modes are reachable, and a claim outlives the call that made it (#40)")
+    from showrunner import roles as R
+
+    SR = [sys.executable, os.path.join(ROOT, "bin", "showrunner")]
+    cfg = make_repo()
+    home = tmpdir("role-verb-home")
+    os.makedirs(os.path.join(home, "showrunner"), exist_ok=True)
+    rp = os.path.join(home, "showrunner", "roles.json")
+    with open(rp, "w") as fh:
+        json.dump({"roles": {
+            "campaign-lead": {"acquire": "claim", "capacity": 1, "may_create": ["worker"],
+                              "writes": {"allow": ["**"]}},
+            "worker": {"acquire": "assign", "reports_to": "campaign-lead"},
+            R.FALLBACK: {"acquire": "claim", "writes": {"deny": ["**"]}}}}, fh)
+
+    def sr(*argv, **kw):
+        env = dict(os.environ, XDG_CONFIG_HOME=kw.pop("xdg", home), NO_COLOR="1")
+        p = subprocess.run(SR + list(argv), cwd=kw.pop("cwd", cfg.root),
+                           capture_output=True, text=True, env=env)
+        return p.returncode, p.stdout, p.stderr
+
+    # NEITHER ACQUISITION MODE WAS REACHABLE. `assign` had no reader until a seat could resolve
+    # through `seat_roles`, and `claim` had no writer at all: `roles.claim` was a library function
+    # with zero callers, and the `claim` VERB claims a leaf. On a stock install that made every
+    # session the fallback whatever its roles said, and seating anything meant importing the
+    # library from Python.
+    rc, out, _err = sr("role", "claim", "campaign-lead", "--session", "sess-1", "--who", "agent-a")
+    eq("`role claim` seats a role from the CLI, which no verb could do", rc, 0)
+    ok("...and states the liveness basis rather than only success — a claim whose pid exits "
+       "reports success too, which is what made the failure silent", "liveness basis" in out, out)
+
+    entries = json.loads(sr("role", "roster", "--json")[1])
+    eq("...and the roster shows that seat HELD",
+       [(e["role"], e["state"]) for e in entries], [("campaign-lead#0", locks.HELD)])
+    ok("...with the basis recorded on the holder, so a reader sees which fact liveness rests on",
+       (entries[0].get("holder") or {}).get("pid_basis"), entries)
+
+    rc, out, _err = sr("whoami", "--session", "sess-1")
+    ok("`whoami` announces the CLAIMED role — the whole path from CLI to announcement, which "
+       "had no first step before", "campaign-lead" in out and "claimed" in out, out[-300:])
+
+    # ONE RESOLVER, TWO RENDERINGS. A hook author with only prose to read reimplements the
+    # resolver, and the copy drifts: a consumer's write guard kept one, did not learn
+    # `seat_roles`, and enforced the deny-everything fallback while `whoami` announced a role.
+    def porcelain(*argv, **kw):
+        """(doc or None). A parse failure is a FINDING, not a traceback — the claim under test is
+        that a hook can consume this, and `None` lets that fail as an assertion."""
+        body = sr(*argv, **kw)[1]
+        try:
+            return json.loads(body)
+        except ValueError:
+            return None
+
+    doc = porcelain("whoami", "--porcelain", "--session", "sess-1")
+    ok("`whoami --porcelain` emits JSON a hook can parse at all — having no machine-readable "
+       "answer is what forced a hook author to keep a copy of the resolver", doc is not None,
+       sr("whoami", "--porcelain", "--session", "sess-1")[1][:200])
+    eq("...resolving the SAME role the prose announced, so a guard and a human cannot be told "
+       "different things", (doc or {}).get("role"), "campaign-lead")
+    ok("...and carries the writes rule a guard has to enforce, which is the field whose absence "
+       "forced the copy", (doc or {}).get("policy", {}).get("writes"), doc)
+    ok("...and exposes `enforced` to branch on, so a parser never has to infer policy from a "
+       "role name", (doc or {}).get("enforced") is True, doc)
+
+    empty = tmpdir("no-roles-home")
+    blind = porcelain("whoami", "--porcelain", xdg=empty) or {}
+    ok("with NO roles defined it says enforced=false and role=null — a guard must not be able "
+       "to read 'no policy exists' as 'this write is permitted'",
+       blind.get("enforced") is False and blind.get("role", "x") is None, blind)
+
+    # A ROLE DECLARING `assign` IS NOT CLAIMABLE. Its entire meaning is that whoever created the
+    # session decided; taking it here would be self-nomination into a seat the model says cannot
+    # be self-nominated.
+    rc, out, err = sr("role", "claim", "worker", "--session", "sess-2")
+    eq("a role declaring acquire=assign is REFUSED, with the PreToolUse deny code", rc, 2)
+    ok("...and the refusal names how an assigned role IS obtained instead of only saying no",
+       "seat_roles" in (out + err), (out + err)[-240:])
+
+    rc, out, err = sr("role", "claim", "nonesuch")
+    eq("an undefined role is refused", rc, 2)
+    ok("...naming what IS defined, so the refusal is actionable rather than a wall",
+       "campaign-lead" in (out + err), (out + err)[-240:])
+
+    rc, out, _err = sr("role", "release", "campaign-lead")
+    eq("`role release` gives the seat back — the counterpart `claim` never had, so a seat could "
+       "previously only be surrendered by outliving it or deleting a file", rc, 0)
+    eq("...and the roster is empty again", json.loads(sr("role", "roster", "--json")[1]), [])
+    ok("...and `whoami` returns to the fallback, so releasing is observable end to end",
+       R.FALLBACK in sr("whoami", "--session", "sess-1")[1], "")
+
+    # THE REPORTED FAILURE, and it is the worst of the three possible outcomes: success reported,
+    # nothing held. A claim keyed to a short-lived process reads STALE the moment that process
+    # exits, so `whoami` announces the fallback while the claimer was told `ok: True`.
+    dead = DeadPid().pid
+    got, h = R.claim(cfg, "campaign-lead", "sess-3", pid=dead, who="agent-c")
+    ok("a claim handed a pid that has ALREADY exited still reports success at the moment of "
+       "claiming, which is precisely why this was silent", got, h)
+    eq("...while the roster reads STALE immediately",
+       [(e["role"], e["state"]) for e in R.roster(cfg)], [("campaign-lead#0", locks.STALE)])
+    orig = R.USER_PATH
+    R.USER_PATH = rp
+    try:
+        defs, _ = R.spec(cfg)
+        eq("...and the resolver skips it, so the session is announced as the fallback despite "
+           "having been told it took the seat", R._resolved(cfg, "sess-3", defs)[0], R.FALLBACK)
+    finally:
+        R.USER_PATH = orig
+    rc, out, err = sr("role", "roster")
+    ok("`role roster` NAMES the stale seat and says those sessions announce the fallback — "
+       "before this the only way to see a dead claim was calling roles.roster() from Python",
+       "STALE" in out and "fallback" in err, (out, err))
+
+    # THE FIX. The pid is DISCOVERED rather than handed over, so the seat outlives the call.
+    R.release(cfg, "campaign-lead", force=True)
+    rc, out, _err = sr("role", "claim", "campaign-lead", "--session", "sess-4")
+    eq("claiming through the verb succeeds", rc, 0)
+    eq("...and the seat is still HELD once the claiming process has EXITED — the CLI process is "
+       "gone by the time this reads, which is exactly the case that produced STALE",
+       [(e["role"], e["state"]) for e in json.loads(sr("role", "roster", "--json")[1])],
+       [("campaign-lead#0", locks.HELD)])
+    ok("...on a pid that is NOT the exited CLI process, which is the whole mechanism",
+       (json.loads(sr("role", "roster", "--json")[1])[0].get("holder") or {}).get("pid_basis")
+       in ("ancestor-claude", "ppid-fallback"),
+       json.loads(sr("role", "roster", "--json")[1]))
+    R.release(cfg, "campaign-lead", force=True)
+
+
 def test_dispatch_guard():
     group("The cheap dispatch path has a gate on it now (#37)")
     from showrunner import roles as R
@@ -6452,6 +6709,8 @@ def main():
                test_self_pin, test_self_vendored_pin, test_roles,
                test_harness_installer_provenance, test_void_run, test_dispatch_guard,
                test_seat_and_whoami, test_crawler_seat_resolves_to_a_role,
+               test_role_seat_verbs,
+               test_close_resolves_paths_against_the_callers_tree,
                test_campaign_scoping,
                test_issue_waker,
                test_central_install,

--- a/test/run.py
+++ b/test/run.py
@@ -3078,6 +3078,111 @@ def test_seat_and_whoami():
         R.USER_PATH = orig
 
 
+def test_crawler_seat_resolves_to_a_role():
+    group("A Crawler spawn placed is not write-denied in the worktree made for it (#40)")
+    from showrunner import roles as R
+
+    cfg = make_repo()
+    g = new_graph(cfg)
+    g.add("work", leaf_id="c1", labels=["backend"])
+    rec = worktree.spawn(cfg, g.show("c1"), actor="crawler-c")
+    campaign.record_spawn(cfg, rec, pid=os.getpid())
+
+    home = tmpdir("seat-roles-home")
+    os.makedirs(os.path.join(home, "showrunner"), exist_ok=True)
+    rp = os.path.join(home, "showrunner", "roles.json")
+    ROLES = {"campaign-lead": {"acquire": "claim", "capacity": 1, "may_create": ["worker"]},
+             "worker": {"acquire": "assign", "reports_to": "campaign-lead",
+                        "writes": {"allow": ["**"]}},
+             R.FALLBACK: {"acquire": "claim", "writes": {"deny": ["**"]}}}
+
+    def write(seat_map):
+        body = {"roles": ROLES}
+        if seat_map is not None:
+            body["seat_roles"] = seat_map
+        with open(rp, "w") as fh:
+            json.dump(body, fh)
+
+    orig, cwd = R.USER_PATH, os.getcwd()
+    R.USER_PATH = rp
+    try:
+        # THE FIXTURE BEFORE THE READ. `spec` over a file that does not exist yet returns {}, and
+        # `_resolved` refuses a role it cannot find in `defs` — so computing this first made every
+        # fallback assertion below hold no matter what the code did, which is the shape of a test
+        # that certifies the defect it was written to catch.
+        write(None)
+        defs, _ = R.spec(cfg)
+        ok("the fixture's roles are actually loaded, so the fallback assertions below could have "
+           "resolved to `worker` and did not", "worker" in defs, sorted(defs))
+        os.chdir(rec["worktree"])
+
+        # THE REGRESSION. Every Crawler resolved to the fallback, whose policy denies writes
+        # everywhere, INSIDE the tree spawn had just made for it to work in. An audit leaf
+        # finished only by routing its evidence around the guard with shell redirection.
+        role_before, how_before = R._resolved(cfg, "sess-c", defs)
+        eq("WITHOUT a mapping the Crawler still resolves to the fallback, so this stays opt-in "
+           "for every consumer who has written none", role_before, R.FALLBACK)
+
+        write({"crawler": "worker"})
+        role, how = R._resolved(cfg, "sess-c", defs)
+        eq("with the seat mapped, the Crawler resolves to the role the USER named for it",
+           role, "worker")
+        ok("...and says it was the campaign record that assigned it, naming the leaf — the "
+           "record spawn wrote before the session existed IS the assignment `assign` meant",
+           "campaign record" in how and "c1" in how, how)
+
+        # A WORKTREE NOBODY RECORDED GRANTS NOTHING, or `git worktree add` is a way to hand
+        # yourself a role. This is the half that keeps the derivation record-based rather than
+        # location-based.
+        hand = os.path.join(tmpdir("hand-rolled-tree"), "wt")
+        rc, _out, _err = util.run(["git", "worktree", "add", "-b", "by-hand", hand],
+                                  cwd=cfg.root)
+        if rc != 0:
+            skip("a hand-added worktree grants nothing", "git worktree add failed")
+        else:
+            os.chdir(hand)
+            eq("a linked worktree NO campaign record names resolves to the fallback even with "
+               "the seat mapped", R._resolved(cfg, "sess-h", defs)[0], R.FALLBACK)
+
+        # AND THE MAIN CHECKOUT IS NOT A CREDENTIAL. Shipping `orchestrator` mapped would put a
+        # lead in every session that happened to be in the right directory, which is the failure
+        # this whole seam replaced.
+        os.chdir(cfg.root)
+        eq("the orchestrator seat is left unmapped, so standing in the main checkout of a repo "
+           "with a campaign confers no role by itself",
+           R._resolved(cfg, "sess-o", defs)[0], R.FALLBACK)
+
+        # A PROJECT MAY NOT REMAP ITS OWN SEAT -- it could otherwise hand itself any role in the
+        # catalog, the widening the definitions left the repo to prevent.
+        merged, problems = R.seat_roles({"seat_roles": {"crawler": "campaign-lead"}})
+        eq("a project remapping a seat the user already mapped loses to the user-level mapping",
+           merged.get("crawler"), "worker")
+        ok("...and the conflict is reported rather than resolved silently",
+           any("user-level" in x for x in problems), problems)
+
+        # A DROPPED MAPPING IS ANNOUNCED, not merely returned. `whoami` is the seam a session
+        # actually reads, and a mapping silently ignored there leaves it told `unassigned` while
+        # a file it cannot see says otherwise.
+        cfg.data["seat_roles"] = {"crawler": "campaign-lead"}
+        os.chdir(rec["worktree"])
+        body = "\n".join(R.whoami(cfg, session="sess-c"))
+        ok("`whoami` says a seat mapping was IGNORED rather than dropping it quietly",
+           "SEAT MAPPING IGNORED" in body, body[-300:])
+        cfg.data.pop("seat_roles", None)
+
+        # A SEAT MAPPED AT A ROLE NOBODY DEFINED resolves to the fallback, which looks exactly
+        # like having written no mapping at all. One typo buys the whole bug back, so `doctor`
+        # refuses rather than leaving it to be discovered as a write denial mid-run.
+        write({"crawler": "wroker"})
+        rc, out, _err = util.run([os.path.join(ROOT, "bin", "showrunner"), "doctor"],
+                                 cwd=cfg.root, env=dict(os.environ, XDG_CONFIG_HOME=home))
+        ok("`doctor` FAILS on a seat mapped at a role no definition provides, naming the seat "
+           "and the typo", rc != 0 and "wroker" in out and "crawler" in out, (rc, out[-400:]))
+    finally:
+        os.chdir(cwd)
+        R.USER_PATH = orig
+
+
 def test_dispatch_guard():
     group("The cheap dispatch path has a gate on it now (#37)")
     from showrunner import roles as R
@@ -5808,6 +5913,10 @@ def test_retracted_doc_claims():
         ("compares every\nrule file **byte-for-byte** against the main checkout",
          "lib/showrunner/harness.py", "showrunner keeps no list of its own",
          "the harness answers which files are rules; showrunner asks and never compares"),
+        ("Nothing writes assignments yet",
+         "lib/showrunner/roles.py", "The campaign record IS the assignment",
+         "`spawn` wrote the assignment all along — keyed to the worktree, before the session "
+         "existed — and `seat_roles` is what finally reads it back"),
     ]
     # WHITESPACE-NORMALISED, because the first version of this scan was VACUOUS and passed. The
     # docs wrap at 96 columns, so "minus the conversation" is stored as "minus the\nconversation"
@@ -6342,7 +6451,8 @@ def main():
                test_integration, test_worktree_lease, test_worktree_guard_from_inside_a_worktree,
                test_self_pin, test_self_vendored_pin, test_roles,
                test_harness_installer_provenance, test_void_run, test_dispatch_guard,
-               test_seat_and_whoami, test_campaign_scoping,
+               test_seat_and_whoami, test_crawler_seat_resolves_to_a_role,
+               test_campaign_scoping,
                test_issue_waker,
                test_central_install,
                test_installer_leaves_no_vendored_copy,


### PR DESCRIPTION
> **Rebased onto `main` by merge, not rebase.** #45 has landed; `main` was merged in with a commit rather than a force-push, so the diff below is only these four fixes.

Four gaps in one seam, all found by deploying it rather than by reading it. Closes #48, #49, #50, and **part 1 of #42**.

> #42 already reported that `roles.claim()` has no caller and proposed these exact three verbs. I filed #47 for it before finding #42, and have closed #47 as a duplicate. **#42 stays open**: its part 2 — no top-level `charter`, no per-role `description` — is untouched here.

---

## 1. Both acquisition modes were unreachable (#42, part 1)

`roles.py` presents two acquisition modes as "the whole model". Neither was obtainable:

- **`assign`** had no reader — fixed in #45.
- **`claim`** had no writer. `roles.claim` was a library function with **zero callers**, the `claim` verb claims a *leaf*, and there was no `release` at any layer.

So on a stock install no role could be acquired by either declared mechanism, and every session got the fallback whatever its roles said. This reframes what #45 fixed: not an edge case, but half of a seam where neither half worked.

```
showrunner role claim campaign-lead --who agent-a
showrunner role roster
showrunner role release campaign-lead
```

Shaped like the existing `lock` / `worktree` / `lease` groups. `role claim` refuses a role declaring `acquire: "assign"` — its whole meaning is that whoever created the session decided, so taking it here would be self-nomination into a seat the model says cannot be self-nominated.

## 2. A claim was dead on arrival (#48)

The one worth reading twice. Liveness is a pid plus a boot token, and `roles.claim` took the pid from its caller. A claim made from a short-lived process therefore reported **success** and read `STALE` the instant that process exited — after which the resolver skipped it and `whoami` announced the fallback again. Success reported, nothing held, symptom appearing far from cause.

**Nothing new was needed to fix it**, which is the interesting part:

- `util.session_pid()` already walks the ancestry and returns a `basis` separating "proved it" from "could not tell".
- `lease` already consumes it, records `pid_basis` on the holder, and refuses outright when nothing resolves.
- `lock acquire` already *prints* this warning: *"the holder recorded is THIS shell, which exits immediately."*

The roles path shared `locks.Lock` with all three and inherited none of the mitigation. It now discovers the pid, records the basis, refuses when none resolves, and warns when liveness rests on a weaker fact.

`role roster` exists because that state had nowhere to be seen — the only way to notice a dead claim was calling `roles.roster()` from Python, and a state nothing surfaces is a state nobody debugs.

## 3. A guard cannot consume prose (#49)

`whoami` emitted English and nothing else, so a hook author needing the resolved role had no way to ask, and reimplemented the resolver. A consumer's `PreToolUse` write guard carried such a copy; when a seat learned to resolve through `seat_roles` the copy did not — so the announcement said one role while the guard enforced the deny-everything fallback, and a session was correctly unable to edit the file it had been dispatched to edit.

That is the failure `enforced_lines` already argues against — *two statements of one policy, free to disagree* — applied inside the announcement and not at its boundary, which is where it broke.

`whoami --porcelain` emits the resolution as data. **The flag is not the point:** `whoami` now *renders* the same dict, so prose and JSON cannot drift; a porcelain computed alongside the prose would only have moved the drift in here.

Two details decide whether a guard can be correct:

- `enforced` is the field to branch on, false whenever showrunner enforces nothing. A null `role` read as "no restriction" is the fail-open reading, and `problems` says which case it is.
- The porcelain exits non-zero when it cannot resolve, so a parser can fail closed. The prose path still exits 0, because a SessionStart hook cannot block and silence is the unacceptable outcome there.

## 4. `close` read the wrong tree's proof (#50)

`gates.close_gate` joined a relative `--proof` against `cfg.root` — the **main checkout** — so an agent passing a relative path to a test it had just written in its own worktree had it resolved against the main checkout, which held a stale copy of the same path. The close was refused as proof predating the claim.

The gate manufactured **the one verdict it exists to produce**, from a correct submission, naming a path the caller recognised while reporting a fact about a file it had never seen. Absolute paths were unaffected, so the bug was invisible to anyone passing those and fatal to anyone typing the relative form that is natural when you are standing in the directory.

Audited every `isabs` in `lib/`: `--premise-read` had the same defect, and so did `amend --evidence`. The `dispatch.py` and `harness.py` joins are config paths, correctly root-relative, and left alone. One helper now serves the three session-supplied sites, with two constraints that keep the fix from relocating the bug:

- **Only a tree of *this* repo** (comparing `--git-common-dir`). A cwd in an unrelated checkout is not the tree the closer is standing in, and resolving a proof into a stranger repo would be this bug pointed somewhere new. From the main checkout the caller's tree *is* `cfg.root`, so nothing changes there.
- **Refusals name the tree they read from.** Resolving correctly fixes the bug; saying where the answer came from is what makes the next one diagnosable.

---

## How each claim was shown to fail

Eight reverts, each with a witness:

| reverted | fails |
|---|---|
| `claim` takes its caller's pid again | 7 assertions, incl. *"still HELD once the claiming process has EXITED"* |
| drop the `acquire=assign` refusal | both refusal assertions |
| drop the `--porcelain` branch | all five porcelain assertions |
| porcelain answers from its own copy | the prose/JSON agreement assertion |
| porcelain reports `enforced=true` | the fail-closed assertion |
| drop the `STALE` note from `roster` | the diagnosability assertion |
| neuter `release` | 7 assertions |
| `close` joins against `cfg.root` again | the false stale refusal, verbatim (below) |

The close mutation reproduces the reported symptom exactly:

```
REFUSED to close c1: --proof (evidence/witness.txt) has not changed since before the leaf
was claimed (artifact 2026-08-19 16:09, claim 2026-08-20 16:09). An artifact older than
the work is evidence about something else.
```

**Two mutations could not be read until the test was fixed, and that is worth recording.** Dropping the porcelain branch made the test raise `JSONDecodeError` rather than fail an assertion. Reverting the close join surfaced a `--premise-read` refusal that fires *before* the staleness check — so the headline claim was witnessing the wrong refusal entirely. Now: a parse failure is captured as a finding, that case's `--premise-read` names a file present in **both** trees so only the proof path can refuse, and the close assertions capture `Refused` instead of letting it abort the test. A mutation that kills the harness instead of failing an assertion tells you almost nothing about which claim was load-bearing.

The close test also pins that the gate was **repaired, not disabled** — a proof in the closer's own tree that genuinely predates the claim is still refused. Turning a false refusal into a false acceptance would be strictly worse than the bug.

## Suite

```
$ XDG_CONFIG_HOME=$(mktemp -d) python3 test/run.py
RESULT: 964 passed, 0 failed, 1 skipped

$ python3 test/run.py
RESULT: 962 passed, 2 failed, 1 skipped
```

The 2 are the pre-existing environment dependency filed as #46 — two assertions read the real user-level `roles.json` — and are not touched here.

## Merge resolution worth a look

`whoami` now renders from `resolution()` so prose and porcelain cannot disagree. #44 landed on `main` first and rewrote the `notes` block in the **old** shape — two changes to the same lines from opposite directions. Resolved by carrying #44's multi-line rendering into the new form: a list still becomes lines rather than a Python repr, now sourced from the same dict a guard parses. Taking either side whole would have silently dropped one of the two fixes, and the suite would only have caught one of those.

`docs/DESIGN.md` also needed retracting, twice. #43 brought it up to date describing a world where `assign` had no writer and `claim` had no caller — true when written, falsified first by #45 and then by this. Each merge retracts precisely the half it invalidates rather than leaving a freshly-corrected design document carrying a known-false paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
