### PR TITLE
chore: example campaign names read as a real ticket in a real backlog

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -238,7 +238,7 @@ handoff a showrunner charges — worktrees, briefs, rooms, integration — is on
 parallelism it buys. So more than one at a time in one checkout is the ORDINARY case.
 
 ```
-SHOWRUNNER_CAMPAIGN=DROP-4130 showrunner status    # state nests under a per-campaign directory
+SHOWRUNNER_CAMPAIGN=my-campaign showrunner status    # state nests under a per-campaign directory
 ```
 
 Graph, campaign record, event journal and scratch all follow the campaign. **Locks deliberately do

--- a/test/run.py
+++ b/test/run.py
@@ -3747,8 +3747,12 @@ def test_campaign_scoping():
        cfg.state_dir, os.path.join(cfg.root, ".showrunner"))
     eq("...and the campaign is None rather than a campaign named ''", cfg.campaign, None)
 
-    a = config.load(start=cfg.root, campaign="DROP-4130 search relevance")
-    b = config.load(start=cfg.root, campaign="DROP-9000")
+    # The name is a placeholder ON PURPOSE, and its SHAPE is load-bearing: mixed case, a space,
+    # a digit and a run of non-alphanumerics are what `slug` has to fold, and this fixture is the
+    # only place that is observed. Rename it and keep those, or the slug assertions below stop
+    # checking anything.
+    a = config.load(start=cfg.root, campaign="My Campaign #2")
+    b = config.load(start=cfg.root, campaign="Another Campaign")
     ok("a selected campaign nests under .showrunner/campaigns/, so it sits beside the default "
        "rather than replacing it",
        a.state_dir.startswith(os.path.join(cfg.root, ".showrunner", "campaigns")), a.state_dir)
@@ -3778,7 +3782,7 @@ def test_campaign_scoping():
     os.environ["SHOWRUNNER_CAMPAIGN"] = "something-else-entirely"
     try:
         ok("a loaded config does not change its answers when the environment moves under it",
-           "drop-4130" in a.graph_db, a.graph_db)
+           "my-campaign-2" in a.graph_db, a.graph_db)
         env_cfg = config.load(start=cfg.root)
         eq("...while a config loaded AFTER the change reads the new value, so the env var is "
            "still the selector and not a one-shot", env_cfg.campaign, "something-else-entirely")


### PR DESCRIPTION
Closes #52.

`llms.txt:241` and the campaign-scoping fixture in `test/run.py` used an external tracker key plus a plausible work-item title as their example campaign name. Together those read as a genuine entry in a genuine backlog rather than as an illustration — a small leak of an outside tracker's namespace into a public repo's front-door docs.

Replaced with names recognisable as placeholders on sight, and deliberately **not** of the form `LETTERS-NNNN`: that shape reads as a tracker key whatever letters are chosen, so swapping the prefix would not have fixed it.

## The fixture's shape was load-bearing

This is the part a rename could quietly break. `slug()` has no direct test, so this fixture is the only place its behaviour is observed:

| property | what it proves |
|---|---|
| mixed case | the slug is lowercased |
| a space | spaces are folded |
| a run of non-alphanumerics | they collapse to **one** hyphen, not several |
| a digit | digits pass through |

The new name keeps all four, and the assertion that reads the resulting slug was changed **with** the fixture rather than loosened to accept whatever came out.

Verified by mutation, because "I kept the coverage" is exactly the claim a rename tends to get wrong:

| reverted | fails |
|---|---|
| `slug` stops lowercasing | `a loaded config does not change its answers when the environment moves under it` |
| `slug` stops collapsing spaces | that one **and** `...slugged, because a campaign is named by a human and a story title is not a path` |

A rename that had weakened the assertion would have left both green.

## The sweep

Swept **every tracked file**, not just the two lines the issue named. The tracker-key shape (`[A-Z]{2,}-[0-9]{3,}`) and a case-insensitive sweep for the specific prefix both return clean afterwards.

The only other `LETTERS-DIGITS` ids in the repo are **this project's own** build-step labels — `WL-nn` and `CI-nn`, defined in `docs/plans/worktree-lease.md` and `docs/plans/central-install.md` — plus illustrative leaf ids like `RPT-02` and `SE-01` in example output. Those are showrunner's own vocabulary, self-documented in-repo, and name no outside system, so they stay. `.game_loop/` is untracked and therefore not part of this repo.

## Suite

```
$ XDG_CONFIG_HOME=$(mktemp -d) python3 test/run.py
RESULT: 964 passed, 0 failed, 1 skipped
```

Unchanged from before, as expected — no assertions were added or removed, only a fixture and the one assertion that reads it. `docs_surface.py` exits 0.

Nothing in git history is rewritten; fixing forward is the whole remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
